### PR TITLE
Fix issue #5: splitting multiple forms.

### DIFF
--- a/Helfrich-1916-wordlist.R
+++ b/Helfrich-1916-wordlist.R
@@ -50,6 +50,41 @@ helfrich_wl <- helfrich_wl |>
 helfrich_wl |> 
   select(-matches("(variant$|variant_com|variant_ipa)")) |> 
   select(ID, page, entry, dutch, english, form, variant_ID, form_common_transcription, form_common_segments, form_ipa_segments, matches("crossref"), everything()) |> 
+  # here we deal with issue #5 https://github.com/engganolang/helfrich-1916-wordlist/issues/5 for splitting multiple forms
+  mutate(form_common_transcription = if_else(str_detect(form, "\\;", negate = TRUE) & str_detect(form, "\\s"),
+                                             str_replace_all(form_common_transcription, "\\s", "_"),
+                                             form_common_transcription),
+         form_common_segments = if_else(str_detect(form, "\\;", negate = TRUE) & str_detect(form, "\\s"),
+                                        str_replace_all(form_common_segments, "\\#", "_"),
+                                        form_common_segments),
+         form_ipa_segments = if_else(str_detect(form, "\\;", negate = TRUE) & str_detect(form, "\\s"),
+                                        str_replace_all(form_ipa_segments, "\\#", "_"),
+                                        form_ipa_segments),
+         form = if_else(str_detect(form, "\\;", negate = TRUE) & str_detect(form, "\\s"),
+                        str_replace_all(form, "\\s", "_"),
+                        form)) |> 
+  separate_longer_delim(cols = matches("(^form_?|^crossref)"), delim = ";") |> 
+  mutate(across(matches("(^form_?|^crossref)"), ~str_trim(., side = "both"))) |> 
+  mutate(across(matches("(^form_?|^crossref)"), ~str_replace_all(., "(^\\#\\s|\\s\\#$)", ""))) |> 
+  mutate(crossref_ID = if_else(str_detect(crossref_ID, "^w[0-9]"),
+                               str_replace_all(crossref_ID, "^w[0-9]_", ""),
+                               crossref_ID)) |> 
+  mutate(form_common_transcription = if_else(str_detect(form, "\\;", negate = TRUE) & str_detect(form, "\\s"),
+                                             str_replace_all(form_common_transcription, "\\s", "_"),
+                                             form_common_transcription),
+         form_common_segments = if_else(str_detect(form, "\\;", negate = TRUE) & str_detect(form, "\\s"),
+                                        str_replace_all(form_common_segments, "\\#", "_"),
+                                        form_common_segments),
+         form_ipa_segments = if_else(str_detect(form, "\\;", negate = TRUE) & str_detect(form, "\\s"),
+                                     str_replace_all(form_ipa_segments, "\\#", "_"),
+                                     form_ipa_segments),
+         form = if_else(str_detect(form, "\\;", negate = TRUE) & str_detect(form, "\\s"),
+                        str_replace_all(form, "\\s", "_"),
+                        form)) |> 
+  mutate(dutch = str_replace_all(dutch, "([,;:?!])", " \\1 "),
+         english = str_replace_all(english, "([,;:?!])", " \\1 "),
+         dutch = str_replace_all(dutch, "\\s{2,}", " "),
+         english = str_replace_all(english, "\\s{2,}", " ")) |> 
   write_tsv("data/helfrich1916.tsv", na = "")
 
 # save the variant table
@@ -57,6 +92,34 @@ helfrich_wl |>
   select(FORM_ID = ID, matches("variant")) |> 
   filter(!is.na(variant)) |> 
   select(ID = variant_ID, everything()) |> 
+  # here we deal with issue #5 https://github.com/engganolang/helfrich-1916-wordlist/issues/5 for splitting multiple forms
+  mutate(variant_common_transcription = if_else(str_detect(variant, "\\;", negate = TRUE) & str_detect(variant, "\\s"),
+                                             str_replace_all(variant_common_transcription, "\\s", "_"),
+                                             variant_common_transcription),
+         variant_common_segments = if_else(str_detect(variant, "\\;", negate = TRUE) & str_detect(variant, "\\s"),
+                                        str_replace_all(variant_common_segments, "\\#", "_"),
+                                        variant_common_segments),
+         variant_ipa_segments = if_else(str_detect(variant, "\\;", negate = TRUE) & str_detect(variant, "\\s"),
+                                     str_replace_all(variant_ipa_segments, "\\#", "_"),
+                                     variant_ipa_segments),
+         variant = if_else(str_detect(variant, "\\;", negate = TRUE) & str_detect(variant, "\\s"),
+                        str_replace_all(variant, "\\s", "_"),
+                        variant)) |> 
+  separate_longer_delim(cols = matches("^variant_?"), delim = ";") |> 
+  mutate(across(matches("^variant_?"), ~str_trim(., side = "both"))) |> 
+  mutate(across(matches("^variant_?"), ~str_replace_all(., "(^\\#\\s|\\s\\#$)", ""))) |> 
+  mutate(variant_common_transcription = if_else(str_detect(variant, "\\;", negate = TRUE) & str_detect(variant, "\\s"),
+                                             str_replace_all(variant_common_transcription, "\\s", "_"),
+                                             variant_common_transcription),
+         variant_common_segments = if_else(str_detect(variant, "\\;", negate = TRUE) & str_detect(variant, "\\s"),
+                                        str_replace_all(variant_common_segments, "\\#", "_"),
+                                        variant_common_segments),
+         variant_ipa_segments = if_else(str_detect(variant, "\\;", negate = TRUE) & str_detect(variant, "\\s"),
+                                     str_replace_all(variant_ipa_segments, "\\#", "_"),
+                                     variant_ipa_segments),
+         variant = if_else(str_detect(variant, "\\;", negate = TRUE) & str_detect(variant, "\\s"),
+                        str_replace_all(variant, "\\s", "_"),
+                        variant)) |> 
   write_tsv("data/helfrich1916_variant.tsv", na = "")
 
 

--- a/data/helfrich1916.tsv
+++ b/data/helfrich1916.tsv
@@ -1,140 +1,145 @@
 ID	page	entry	dutch	english	form	variant_ID	form_common_transcription	form_common_segments	form_ipa_segments	crossref_form	crossref_common_transcription	crossref_common_segments	crossref_ID	crossref_ipa_segments	comment
 1	475	A	oudere broeder of zuster	elderly brother or sister	aääoe		a'a'au	a ' a ' a u	a ʔ a ʔ a u						
-2	475	A	neersmijten, neersmakken	throw down, knock down	aäpoe(w)a(q)	16	a'apu(w)a(')	a ' a p u ( w ) a ( ' )	a ʔ a p u ( w ) a ( ʔ )						
-3	475	A	in, te, op	in, at, on	aba		aba	a b a	a b a						
+2	475	A	neersmijten , neersmakken	throw down , knock down	aäpoe(w)a(q)	16	a'apu(w)a(')	a ' a p u ( w ) a ( ' )	a ʔ a p u ( w ) a ( ʔ )						
+3	475	A	in , te , op	in , at , on	aba		aba	a b a	a b a						
 4	475	A	negen	nine	abaiekahaieq	18	abaikahai'	a b a i k a h a i '	a b a i k a h a i ʔ						
-5	475	A	geleiden, begeleiden	guide, accompany	abakoe(w)a(q)	19	abaku(w)a(')	a b a k u ( w ) a ( ' )	a b a k u ( w ) a ( ʔ )						
+5	475	A	geleiden , begeleiden	guide , accompany	abakoe(w)a(q)	19	abaku(w)a(')	a b a k u ( w ) a ( ' )	a b a k u ( w ) a ( ʔ )						
 6	475	A	last van iemand die heengaat	burden of someone leaving	abaoe(w)aie(j)onie(j)a		abau(w)ai(y)oni(y)a	a b a u ( w ) a i ( y ) o n i ( y ) a	a b a u ( w ) a i ( j ) o n i ( j ) a						
-7	475	A	onderzoek, navraag	investigation, enquiry	abapoe(w)apaoe(w)a		abapu(w)apau(w)a	a b a p u ( w ) a p a u ( w ) a	a b a p u ( w ) a p a u ( w ) a						
+7	475	A	onderzoek , navraag	investigation , enquiry	abapoe(w)apaoe(w)a		abapu(w)apau(w)a	a b a p u ( w ) a p a u ( w ) a	a b a p u ( w ) a p a u ( w ) a						
 8	475	A	bamboeriet	bamboo reed	abèha	460	abEha	a b E h a	a b ɛ h a						
 9	475	A	braken	vomit	abèo		abEo	a b E o	a b ɛ o						
-10	475	A	aandoen, aanhebben, gebruiken, zooals kleederen	put on, have on, use, such as clothes	aboeaqä		abua'a	a b u a ' a	a b u a ʔ a						
-11	475	A	afgedaan, klaar, reeds, voltooid, gereed, ten einde, in orde gekomen uit een verwarden toestand, gedaan hebben met iets, tot rust gekomen	finished, ready, already, completed, finished, finished, finished, come in order from a confused state, done with something, come to rest	aböha		abu̇ha	a b u̇ h a	a b ɨ h a						
-12	475	A	herwaarts, hierheen	hither, here	adèq	43	adE'	a d E '	a d ɛ ʔ						
-13	475	A	antwoord, antwoorden, antwoord geven	answer, reply, give answer	adie	44	adi	a d i	a d i						
+10	475	A	aandoen , aanhebben , gebruiken , zooals kleederen	put on , have on , use , such as clothes	aboeaqä		abua'a	a b u a ' a	a b u a ʔ a						
+11	475	A	afgedaan , klaar , reeds , voltooid , gereed , ten einde , in orde gekomen uit een verwarden toestand , gedaan hebben met iets , tot rust gekomen	finished , ready , already , completed , finished , finished , finished , come in order from a confused state , done with something , come to rest	aböha		abu̇ha	a b u̇ h a	a b ɨ h a						
+12	475	A	herwaarts , hierheen	hither , here	adèq	43	adE'	a d E '	a d ɛ ʔ						
+13	475	A	antwoord , antwoorden , antwoord geven	answer , reply , give answer	adie	44	adi	a d i	a d i						
 14	475	A	vijf	five	adieba	46	adiba	a d i b a	a d i b a						
-15	475	A	zeven	seven	adieba hie adoe(w)a	45	adiba hi adu(w)a	a d i b a # h i # a d u ( w ) a	a d i b a # h i # a d u ( w ) a						
-16	475	A	kwaad doen, kwaad stichten	do evil, cause evil	ado		ado	a d o	a d o						
+15	475	A	zeven	seven	adieba_hie_adoe(w)a	45	adiba_hi_adu(w)a	a d i b a _ h i _ a d u ( w ) a	a d i b a _ h i _ a d u ( w ) a						
+16	475	A	kwaad doen , kwaad stichten	do evil , cause evil	ado		ado	a d o	a d o						
 17	475	A	twee	two	adoe(w)a	50	adu(w)a	a d u ( w ) a	a d u ( w ) a						
-18	475	A	roepen, bij den naam roepen, noemen	call, call by name, mention	ahadie		ahadi	a h a d i	a h a d i						
-19	475	A	zich oprichten, opstaan, overeind zetten	raise oneself up, stand up, put upright	ahado		ahado	a h a d o	a h a d o						
-20	475	A	met de hand drukkend over een lichaamsdeel strijken	stroke a part of the body with the hand, pressing it	ahapieorie		ahapiori	a h a p i o r i	a h a p i o r i						
-21	475	A	hoop, stapel, opgehoopt	hope, pile, accumulated	ahapoie		ahapoi	a h a p o i	a h a p o i						
-22	475	A	verzoek, verzoeken	request, requests	aharie		ahari	a h a r i	a h a r i						
-23	475	A	kiezen, uitkiezen, een keuze doen uit	choose, pick, make a choice from	aharieohoie		ahariohoi	a h a r i o h o i	a h a r i o h o i						
-24	475	A	besproeien, begieten	spray, water	ahèmoie		ahEmoi	a h E m o i	a h ɛ m o i						
-25	475	A	verbranden, in brand steken	burn, set on fire	ahiebie		ahibi	a h i b i	a h i b i						
+18	475	A	roepen , bij den naam roepen , noemen	call , call by name , mention	ahadie		ahadi	a h a d i	a h a d i						
+19	475	A	zich oprichten , opstaan , overeind zetten	raise oneself up , stand up , put upright	ahado		ahado	a h a d o	a h a d o						
+20	475	A	met de hand drukkend over een lichaamsdeel strijken	stroke a part of the body with the hand , pressing it	ahapieorie		ahapiori	a h a p i o r i	a h a p i o r i						
+21	475	A	hoop , stapel , opgehoopt	hope , pile , accumulated	ahapoie		ahapoi	a h a p o i	a h a p o i						
+22	475	A	verzoek , verzoeken	request , requests	aharie		ahari	a h a r i	a h a r i						
+23	475	A	kiezen , uitkiezen , een keuze doen uit	choose , pick , make a choice from	aharieohoie		ahariohoi	a h a r i o h o i	a h a r i o h o i						
+24	475	A	besproeien , begieten	spray , water	ahèmoie		ahEmoi	a h E m o i	a h ɛ m o i						
+25	475	A	verbranden , in brand steken	burn , set on fire	ahiebie		ahibi	a h i b i	a h i b i						
 26	475	A			ahiemahona		ahimahona	a h i m a h o n a	a h i m a h o n a	mahona	mahona	m a h o n a		m a h o n a	
-27	475	A	gedachte, nadenken, overdenken	thought, ponder, contemplate	ahopaq		ahopa'	a h o p a '	a h o p a ʔ						
-28	475	A	groot, dik, zwaar	big, fat, heavy	aieiejo		aiiyo	a i i y o	a i i j o						
-29	475	A	achteruitgaan, achterwaarts gaan	going backwards, going backwards	aiekoie	25	aikoi	a i k o i	a i k o i						
-30	475	A	achteruitgaan, achterwaarts gaan	going backwards, going backwards	aiekoie(j)aq	26	aikoi(y)a'	a i k o i ( y ) a '	a i k o i ( j ) a ʔ						
-31	475	A	volgen, achternagaan, gehoorzamen, navolgen	follow chase, obey, follow	ajoqoie		ayo'oi	a y o ' o i	a j o ʔ o i						
+27	475	A	gedachte , nadenken , overdenken	thought , ponder , contemplate	ahopaq		ahopa'	a h o p a '	a h o p a ʔ						
+28	475	A	groot , dik , zwaar	big , fat , heavy	aieiejo		aiiyo	a i i y o	a i i j o						
+29	475	A	achteruitgaan , achterwaarts gaan	going backwards , going backwards	aiekoie	25	aikoi	a i k o i	a i k o i						
+30	475	A	achteruitgaan , achterwaarts gaan	going backwards , going backwards	aiekoie(j)aq	26	aikoi(y)a'	a i k o i ( y ) a '	a i k o i ( j ) a ʔ						
+31	475	A	volgen , achternagaan , gehoorzamen , navolgen	follow chase , obey , follow	ajoqoie		ayo'oi	a y o ' o i	a j o ʔ o i						
 32	475	A	zes	six	akieäkiena	31	aki'akina	a k i ' a k i n a	a k i ʔ a k i n a						
-33	476	A	aan iets denken, zich iets herinneren, op zijne hoede zijn, het bewust denken, zich bewust zijn	thinking of something, remembering something, being on one's guard, thinking it consciously, being aware of it	akiedaq	32	akida'	a k i d a '	a k i d a ʔ						
+33	476	A	aan iets denken , zich iets herinneren , op zijne hoede zijn , het bewust denken , zich bewust zijn	thinking of something , remembering something , being on one's guard , thinking it consciously , being aware of it	akiedaq	32	akida'	a k i d a '	a k i d a ʔ						
 34	476	A	wees op uwe hoede	be on your guard	akiedaqöö		akida'u̇u̇	a k i d a ' u̇ u̇	a k i d a ʔ ɨ ɨ						
-35	476	A	ik herinner het mij weder	I remember again	oe(w)aho bakiekiedaq		u(w)aho bakikida'	u ( w ) a h o # b a k i k i d a '	u ( w ) a h o # b a k i k i d a ʔ						
+35	476	A	ik herinner het mij weder	I remember again	oe(w)aho_bakiekiedaq		u(w)aho_bakikida'	u ( w ) a h o _ b a k i k i d a '	u ( w ) a h o _ b a k i k i d a ʔ						
 36	476	A	in de zonnehitte gedroogd	dried in the heat of the sun	akiehaäq	28	akiha'a'	a k i h a ' a '	a k i ç a ʔ a ʔ						
-37	476	A	kiezen, uitkiezen, eene keuze doen uit	choose, pick, choose between	akienaie	29	akinai	a k i n a i	a k i n a i						
-38	476	A	vermeerderen, toenemen	multiply, increase	akohaie; maäkohaie		akohai; ma'akohai	a k o h a i ; # m a ' a k o h a i	a k o h a i ; # m a ʔ a k o h a i						
+37	476	A	kiezen , uitkiezen , eene keuze doen uit	choose , pick , choose between	akienaie	29	akinai	a k i n a i	a k i n a i						
+38	476	A	vermeerderen , toenemen	multiply , increase	akohaie		akohai	a k o h a i	a k o h a i						
+38	476	A	vermeerderen , toenemen	multiply , increase	maäkohaie		ma'akohai	m a ' a k o h a i	m a ʔ a k o h a i						
 39	476	A	drie	three	akoloe	34	akolu	a k o l u	a k o l u						
 40	476	A	vader	father	ama		ama	a m a	a m a						
-41	476	A	deel, aandeel	part, share	amahèaqja	73	amahEa'ya	a m a h E a ' y a	a m a h ɛ a ʔ j a						
+41	476	A	deel , aandeel	part , share	amahèaqja	73	amahEa'ya	a m a h E a ' y a	a m a h ɛ a ʔ j a						
 42	476	A	schoonouders van den man	husband's parents-in-law	amanaie		amanai	a m a n a i	a m a n a i						
-43	476	A	van een ander nemen of overnemen, aannemen, nemen, wegnemen, halen	take or take over from another, take, take away, fetch	amĕnaq		amėna'	a m ė n a '	a m ə n a ʔ						
-44	476	A	eten, gaan eten	eat, go to eat	amĕno	36	amėno	a m ė n o	a m ə n o						
-45	476	A	door een band vastmaken, aanbinden, vastbinden, omwinden of vastbinden van een voorwerp om als merk of teeken te dienen	to bind, tether, tie up, wrap or tie down an object by a band to serve as a mark or sign	amèq		amE'	a m E '	a m ɛ ʔ						
+43	476	A	van een ander nemen of overnemen , aannemen , nemen , wegnemen , halen	take or take over from another , take , take away , fetch	amĕnaq		amėna'	a m ė n a '	a m ə n a ʔ						
+44	476	A	eten , gaan eten	eat , go to eat	amĕno	36	amėno	a m ė n o	a m ə n o						
+45	476	A	door een band vastmaken , aanbinden , vastbinden , omwinden of vastbinden van een voorwerp om als merk of teeken te dienen	to bind , tether , tie up , wrap or tie down an object by a band to serve as a mark or sign	amèq		amE'	a m E '	a m ɛ ʔ						
 46	476	A	de gesloten hand	the closed hand	amoeapo	35	amuapo	a m u a p o	a m u a p o						
-47	476	A	lang, uitgestrekt van ruimte en tijd	long, vast of space and time	amoehoe; èienoeqoe(q)	37	amuhu; Einu'u(')	a m u h u ; # E i n u ' u ( ' )	a m u h u ; # ɛ i n u ʔ u ( ʔ )						
-48	476	A	grof, ruw	coarse, rough	èkariehie		Ekarihi	E k a r i h i	ɛ k a r i ç i						
-49	476	A	hoog, hoogte	high, height	èkienè	143	EkinE	E k i n E	ɛ k i n ɛ						
-50	476	A	gaan, weggaan, heengaan	go, go away	ana		ana	a n a	a n a						
+47	476	A	lang , uitgestrekt van ruimte en tijd	long , vast of space and time	amoehoe	37	amuhu	a m u h u	a m u h u						
+47	476	A	lang , uitgestrekt van ruimte en tijd	long , vast of space and time	èienoeqoe(q)	37	Einu'u(')	E i n u ' u ( ' )	ɛ i n u ʔ u ( ʔ )						
+48	476	A	grof , ruw	coarse , rough	èkariehie		Ekarihi	E k a r i h i	ɛ k a r i ç i						
+49	476	A	hoog , hoogte	high , height	èkienè	143	EkinE	E k i n E	ɛ k i n ɛ						
+50	476	A	gaan , weggaan , heengaan	go , go away	ana		ana	a n a	a n a						
 51	476	A	de pandanus	the pandanus	aniemaie	462	animai	a n i m a i	a n i m a i						
 52	476	A	rooken	smoke	anoekoöq		anuko'o'	a n u k o ' o '	a n u k o ʔ o ʔ						
-53	476	A	laag, rij voorwerpen op of naast elkander	layer, row of objects on or next to each other	anohakèkè		anohakEkE	a n o h a k E k E	a n o h a k ɛ k ɛ						
-54	476	A	makker, kameraad	companion, comrade	anoqö	40	ano'u̇	a n o ' u̇	a n o ʔ ɨ						
+53	476	A	laag , rij voorwerpen op of naast elkander	layer , row of objects on or next to each other	anohakèkè		anohakEkE	a n o h a k E k E	a n o h a k ɛ k ɛ						
+54	476	A	makker , kameraad	companion , comrade	anoqö	40	ano'u̇	a n o ' u̇	a n o ʔ ɨ						
 55	476	A	tegenhouden	hold back	anokè		anokE	a n o k E	a n o k ɛ						
-56	476	A	naar zich toetrekken of halen, voorttrekken	pull or fetch, pull forward	anokie		anoki	a n o k i	a n o k i						
+56	476	A	naar zich toetrekken of halen , voorttrekken	pull or fetch , pull forward	anokie		anoki	a n o k i	a n o k i						
 57	476	A	aan beide einden van een stok over den schouder dragen	carried on both ends of a stick over the shoulder	anoöho		ano'oho	a n o ' o h o	a n o ʔ o h o						
-58	476	A	uitgestort, vergoten	poured out, shed	anoqè(j)a	39	ano'E(y)a	a n o ' E ( y ) a	a n o ʔ ɛ ( j ) a						
+58	476	A	uitgestort , vergoten	poured out , shed	anoqè(j)a	39	ano'E(y)a	a n o ' E ( y ) a	a n o ʔ ɛ ( j ) a						
 59	476	A	bez. vnwd. van den eersten persoon	possessive pronoun of the first person	aoe		au	a u	a u						
-60	476	A	voor, vooruit, eerste	before, ahead, first	aoedoe	41	audu	a u d u	a u d u	èoedoe	Eudu	E u d u	238 ; 556	ɛ u d u	
+60	476	A	voor , vooruit , eerste	before , ahead , first	aoedoe	41	audu	a u d u	a u d u	èoedoe	Eudu	E u d u	238	ɛ u d u	
+60	476	A	voor , vooruit , eerste	before , ahead , first	aoedoe	41	audu	a u d u	a u d u	èoedoe	Eudu	E u d u	556	ɛ u d u	
 61	476	A	vier	four	a(o)pa	10	a(o)pa	a ( o ) p a	a ( o ) p a						
 62	476	A	acht	eight	a(o)pahiea(o)pa	14	a(o)pahia(o)pa	a ( o ) p a h i a ( o ) p a	a ( o ) p a h i a ( o ) p a						
 63	476	A	wieden	weed	apieaie		apiai	a p i a i	a p i a i						
-64	476	A	vermoeid, moeilijk van een werk, zwaar van een werk	tired, difficult of a work, heavy of a work	a(p)ie(j)aka		a(p)i(y)aka	a ( p ) i ( y ) a k a	a ( p ) i ( j ) a k a						
-65	476	A	vermoeid, moeilijk van een werk, zwaar van een werk	tired, hard of a job, heavy of a job	kie(a)pie(j)aka		ki(a)pi(y)aka	k i ( a ) p i ( y ) a k a	k i ( a ) p i ( j ) a k a						
-66	476	A	zich aansluiten, dicht naast elkander plaatsen, doen aansluiten, aan iets dringen	join, place close together, make join, push on to something	apienie		apini	a p i n i	a p i n i						
-67	476	A	blazen, wegblazen, blazen van den wind	blowing, blowing away, blowing the wind<	apoie		apoi	a p o i	a p o i						
+64	476	A	vermoeid , moeilijk van een werk , zwaar van een werk	tired , difficult of a work , heavy of a work	a(p)ie(j)aka		a(p)i(y)aka	a ( p ) i ( y ) a k a	a ( p ) i ( j ) a k a						
+65	476	A	vermoeid , moeilijk van een werk , zwaar van een werk	tired , hard of a job , heavy of a job	kie(a)pie(j)aka		ki(a)pi(y)aka	k i ( a ) p i ( y ) a k a	k i ( a ) p i ( j ) a k a						
+66	476	A	zich aansluiten , dicht naast elkander plaatsen , doen aansluiten , aan iets dringen	join , place close together , make join , push on to something	apienie		apini	a p i n i	a p i n i						
+67	476	A	blazen , wegblazen , blazen van den wind	blowing , blowing away , blowing the wind<	apoie		apoi	a p o i	a p o i						
 68	476	A	3 à 4 u. n.m.	3 to 4 p.m.	apoie		apoi	a p o i	a p o i						
-69	477	A	9 u. v.m.; (lett.: afsluiten van de ronde opening, waardoor men de woning binnengaat, bij het gaan naar het veld, omstreeks 9 u. v.m.).	9 a.m.; (lit.: closing the round opening, through which one enters the dwelling, on going to the field, about 9 a.m.).	aroekoe(w)a	52	aruku(w)a	a r u k u ( w ) a	a r u k u ( w ) a	è(a)karoba	E(a)karoba	E ( a ) k a r o b a	162	ɛ ( a ) k a r o b a	
-70	477	A	9 u. v.m.; (lett.: afsluiten van de ronde opening, waardoor men de woning binnengaat, bij het gaan naar het veld, omstreeks 9 u. v.m.).	9 a.m.; (lit.: closing the round opening, through which one enters the dwelling, when going to the field, about 9 a.m.).	aroekoe(w)a è(a)karoba	53	aruku(w)a E(a)karoba	a r u k u ( w ) a # E ( a ) k a r o b a	a r u k u ( w ) a # ɛ ( a ) k a r o b a	è(a)karoba	E(a)karoba	E ( a ) k a r o b a	162	ɛ ( a ) k a r o b a	
+69	477	A	9 u. v.m. ; (lett. : afsluiten van de ronde opening , waardoor men de woning binnengaat , bij het gaan naar het veld , omstreeks 9 u. v.m.).	9 a.m. ; (lit. : closing the round opening , through which one enters the dwelling , on going to the field , about 9 a.m.).	aroekoe(w)a	52	aruku(w)a	a r u k u ( w ) a	a r u k u ( w ) a	è(a)karoba	E(a)karoba	E ( a ) k a r o b a	162	ɛ ( a ) k a r o b a	
+70	477	A	9 u. v.m. ; (lett. : afsluiten van de ronde opening , waardoor men de woning binnengaat , bij het gaan naar het veld , omstreeks 9 u. v.m.).	9 a.m. ; (lit. : closing the round opening , through which one enters the dwelling , when going to the field , about 9 a.m.).	aroekoe(w)a_è(a)karoba	53	aruku(w)a_E(a)karoba	a r u k u ( w ) a _ E ( a ) k a r o b a	a r u k u ( w ) a _ ɛ ( a ) k a r o b a	è(a)karoba	E(a)karoba	E ( a ) k a r o b a	162	ɛ ( a ) k a r o b a	
 71	477	A	wrijven van de borst van een borstlijder met pisangbladeren	rubbing the chest of a breast sufferer with pisang leaves	aroeoeieoe(w)a		aru'uiu(w)a	a r u ' u i u ( w ) a	a r u ʔ u i u ( w ) a						
-72	477	A	gaan, weggaan, heengaan	go, leave, go away	awa(h)		awa(h)	a w a ( h )	a w a ( h )						
-73	477	A	teruggaan, terugkeeren	going back, returning	awanaq		awana'	a w a n a '	a w a n a ʔ						
-74	477	B	hersteld, gezond.	recovered, healthy.	ba(a)oe(w)a		ba(a)u(w)a	b a ( a ) u ( w ) a	b a ( a ) u ( w ) a						grwd.: aoe(w)a?
-75	477	B	groot, zwaar	large, heavy	baba; oebaba		baba; ubaba	b a b a ; # u b a b a	b a b a ; # u b a b a						
-76	477	B	(mal.); waarmede een in Ned. Indië geboren Chinees wordt aangesproken	(mal.); by which a Chinese born in the Dutch East Indies is addressed	baba; oebaba		baba; ubaba	b a b a ; # u b a b a	b a b a ; # u b a b a						malay
-77	477	B	(mal.); kleedingstuk voor het bovenlijf, baadje	(mal.); garment for the upper body, shirt	badjoe		baju	b a j u	b a d͡ʒ u						malay
+72	477	A	gaan , weggaan , heengaan	go , leave , go away	awa(h)		awa(h)	a w a ( h )	a w a ( h )						
+73	477	A	teruggaan , terugkeeren	going back , returning	awanaq		awana'	a w a n a '	a w a n a ʔ						
+74	477	B	hersteld , gezond.	recovered , healthy.	ba(a)oe(w)a		ba(a)u(w)a	b a ( a ) u ( w ) a	b a ( a ) u ( w ) a						grwd.: aoe(w)a?
+75	477	B	groot , zwaar	large , heavy	baba		baba	b a b a	b a b a						
+75	477	B	groot , zwaar	large , heavy	oebaba		ubaba	u b a b a	u b a b a						
+76	477	B	(mal.) ; waarmede een in Ned. Indië geboren Chinees wordt aangesproken	(mal.) ; by which a Chinese born in the Dutch East Indies is addressed	baba		baba	b a b a	b a b a						malay
+76	477	B	(mal.) ; waarmede een in Ned. Indië geboren Chinees wordt aangesproken	(mal.) ; by which a Chinese born in the Dutch East Indies is addressed	oebaba		ubaba	u b a b a	u b a b a						malay
+77	477	B	(mal.) ; kleedingstuk voor het bovenlijf , baadje	(mal.) ; garment for the upper body , shirt	badjoe		baju	b a j u	b a d͡ʒ u						malay
 78	477	B	avond	evening	bahabaieba	54	bahabaiba	b a h a b a i b a	b a h a b a i b a						
 79	477	B	offermaal	sacrificial meal	bahora		bahora	b a h o r a	b a h o r a						
 80	477	B	zoeken	search	baoe(w)adie	55	bau(w)adi	b a u ( w ) a d i	b a u ( w ) a d i						
-81	477	B	(mal.); ontelbaar	(mal.); innumerable	barieboerieboe		bariburibu	b a r i b u r i b u	b a r i b u r i b u						malay
-82	477	B	(mal.); houweel	(mal.); pickaxe	bĕlie(j)oeng		bėli(y)ung	b ė l i ( y ) u n g	b ə l i ( j ) u n g						malay
-83	477	B	(mal.); draad, garen	(mal.); thread, yarn	bĕnang		bėnang	b ė n a n g	b ə n a n g						malay
-84	477	B	mijnheer, heer	sir, gentleman	biedie	56	bidi	b i d i	b i d i						
+81	477	B	(mal.) ; ontelbaar	(mal.) ; innumerable	barieboerieboe		bariburibu	b a r i b u r i b u	b a r i b u r i b u						malay
+82	477	B	(mal.) ; houweel	(mal.) ; pickaxe	bĕlie(j)oeng		bėli(y)ung	b ė l i ( y ) u n g	b ə l i ( j ) u n g						malay
+83	477	B	(mal.) ; draad , garen	(mal.) ; thread , yarn	bĕnang		bėnang	b ė n a n g	b ə n a n g						malay
+84	477	B	mijnheer , heer	sir , gentleman	biedie	56	bidi	b i d i	b i d i						
 85	477	B			boe		bu	b u	b u	moe	mu	m u	1183	m u	
 86	477	B	voorvoegsel tot vorming van het toestandswoord	prefix to form the state word	boe		bu	b u	b u						
 87	477	B	spuiten van of met water of iets dergelijks	spray of or with water or something like that	boeboeqie		bubu'i	b u b u ' i	b u b u ʔ i						
 88	477	B	5 .uur in den morgen	5 .o'clock in the morning	boedahiejaq		budahiya'	b u d a h i y a '	b u d a h i j a ʔ						
 89	477	B	lengte van duur of tijd	length of duration or time	boeodo		buodo	b u o d o	b u o d o						
-90	477	B	(zelden) oud, in tegenstelling van nieuw	(rarely) old, as opposed to new	boeodo		buodo	b u o d o	b u o d o						
-91	477	D	man, echtgenoot	man, husband	dadoe(oe)		dadu(u)	d a d u ( u )	d a d u ( u )						
-92	477	D	de navolgende dag, overmorgen	the following day, the day after tomorrow	daiekahadie(j)a	58	daikahadi(y)a	d a i k a h a d i ( y ) a	d a i k a h a d i ( j ) a						
+90	477	B	(zelden) oud , in tegenstelling van nieuw	(rarely) old , as opposed to new	boeodo		buodo	b u o d o	b u o d o						
+91	477	D	man , echtgenoot	man , husband	dadoe(oe)		dadu(u)	d a d u ( u )	d a d u ( u )						
+92	477	D	de navolgende dag , overmorgen	the following day , the day after tomorrow	daiekahadie(j)a	58	daikahadi(y)a	d a i k a h a d i ( y ) a	d a i k a h a d i ( j ) a						
 93	477	D	hoofd inz. van een landschap	head of a landscape	dajo		dayo	d a y o	d a j o						
-94	477	D	optillen, opbeuren	lift, uplift	daraqie		dara'i	d a r a ' i	d a r a ʔ i						
+94	477	D	optillen , opbeuren	lift , uplift	daraqie		dara'i	d a r a ' i	d a r a ʔ i						
 95	477	D	(mal.) hoofddoek	(mal.) headscarf	dètar		dEtar	d E t a r	d ɛ t a r						malay
 96	477	D	bez. vnmwd. voor den derden persoon	possessive pronoun for the third person	die(j)a	59	di(y)a	d i ( y ) a	d i ( j ) a						
-97	477	D	hersteld, gezond	recovered, healthy	dja(ä)oe(w)a		ja('a)u(w)a	j a ( ' a ) u ( w ) a	d͡ʒ a ( ʔ a ) u ( w ) a						grwd.: aoe(w)a?
+97	477	D	hersteld , gezond	recovered , healthy	dja(ä)oe(w)a		ja('a)u(w)a	j a ( ' a ) u ( w ) a	d͡ʒ a ( ʔ a ) u ( w ) a						grwd.: aoe(w)a?
 98	477	D	in of met de hand vasthouden	holding in or with the hand	dodo		dodo	d o d o	d o d o						
 99	477	D	erfdeel	share of inheritance	dödöhöka		du̇du̇hu̇ka	d u̇ d u̇ h u̇ k a	d ɨ d ɨ h ɨ k a						
-100	477	D	standhouden, uithouden	hold out, endure	dodokaqäq		dodoka'a'	d o d o k a ' a '	d o d o k a ʔ a ʔ						
-101	478	E	afstooten, wegstooten, afwijzen, wegduwen	repel, repel, reject, push away	è		E	E	ɛ						
-102	478	E	been, gebeente	bone, skeleton	èa		Ea	E a	ɛ a						
+100	477	D	standhouden , uithouden	hold out , endure	dodokaqäq		dodoka'a'	d o d o k a ' a '	d o d o k a ʔ a ʔ						
+101	478	E	afstooten , wegstooten , afwijzen , wegduwen	repel , repel , reject , push away	è		E	E	ɛ						
+102	478	E	been , gebeente	bone , skeleton	èa		Ea	E a	ɛ a						
 103	478	E	schelp	shell	èa		Ea	E a	ɛ a						
 104	478	E	de stijlen van eene woning	the styles of a house	èaähaie		Ea'ahai	E a ' a h a i	ɛ a ʔ a h a i						
 105	478	E	zwemmen	swimming	èaä(h)ko	184	Ea'a(h)ko	E a ' a ( h ) k o	ɛ a ʔ a ( h ) k o						
 106	478	E	zwemmen	swimming	maä(h)ko	416	ma'a(h)ko	m a ' a ( h ) k o	m a ʔ a ( h ) k o						
-107	478	E	asch, stof	ash, dust	èa(ä)haoie		Ea('a)haoi	E a ( ' a ) h a o i	ɛ a ( ʔ a ) h a o i						
-108	478	E	zegen, geluk, levensonderhoud, levensmiddelen	blessing, happiness, sustenance, food	èaäkoe		Ea'aku	E a ' a k u	ɛ a ʔ a k u						
-109	478	E	handeling, gedrag, handelwijze	action, behavior, course of action	èaäkoha		Ea'akoha	E a ' a k o h a	ɛ a ʔ a k o h a						
+107	478	E	asch , stof	ash , dust	èa(ä)haoie		Ea('a)haoi	E a ( ' a ) h a o i	ɛ a ( ʔ a ) h a o i						
+108	478	E	zegen , geluk , levensonderhoud , levensmiddelen	blessing , happiness , sustenance , food	èaäkoe		Ea'aku	E a ' a k u	ɛ a ʔ a k u						
+109	478	E	handeling , gedrag , handelwijze	action , behavior , course of action	èaäkoha		Ea'akoha	E a ' a k o h a	ɛ a ʔ a k o h a						
 110	478	E	ijzer	iron	èaäoe		Ea'au	E a ' a u	ɛ a ʔ a u						
 111	478	E	oudere broeder of zuster	older brother or sister	èaäq		Ea'a'	E a ' a '	ɛ a ʔ a ʔ						
-112	478	E	ziekte, pijn, kwelling	illness, pain, torment	èabaä		Eaba'a	E a b a ' a	ɛ a b a ʔ a						
+112	478	E	ziekte , pijn , kwelling	illness , pain , torment	èabaä		Eaba'a	E a b a ' a	ɛ a b a ʔ a						
 113	478	E	dood	dead	èabaäo		Eaba'ao	E a b a ' a o	ɛ a b a ʔ a o						
-114	478	E	werktuigen, gereedschappen	implements, tools	èabadie(j)o	65	Eabadi(y)o	E a b a d i ( y ) o	ɛ a b a d i ( j ) o						
+114	478	E	werktuigen , gereedschappen	implements , tools	èabadie(j)o	65	Eabadi(y)o	E a b a d i ( y ) o	ɛ a b a d i ( j ) o						
 115	478	E	medelijden	pity	èabaoekiedaie	64	Eabaukidai	E a b a u k i d a i	ɛ a b a u k i d a i						
 116	478	E	één der typen van eene Engganeesche lans	one of the types of an Engganese lance	èabaoe(w)a		Eabau(w)a	E a b a u ( w ) a	ɛ a b a u ( w ) a						
 117	478	E	zekere pisangsoort	certain pisang species	èabo		Eabo	E a b o	ɛ a b o						
-118	478	E	verblijfplaats, woonplaats	abode, dwelling place	èaboebaja		Eabubaya	E a b u b a y a	ɛ a b u b a j a						
-119	478	E	hemel, uitspansel.	sky, expanse.	èadahohoe		Eadahohu	E a d a h o h u	ɛ a d a h o h u						
+118	478	E	verblijfplaats , woonplaats	abode , dwelling place	èaboebaja		Eabubaya	E a b u b a y a	ɛ a b u b a j a						
+119	478	E	hemel , uitspansel.	sky , expanse.	èadahohoe		Eadahohu	E a d a h o h u	ɛ a d a h o h u						
 120	478	E	roosteren van den buik boven een goed onderhouden houtvuur om een abortus op te wekken.	roasting the belly over a well-kept wood fire to induce an abortion.	èadieho		Eadiho	E a d i h o	ɛ a d i ç o						
 121	478	E	zekere soort van bamboeriet	certain kind of bamboo reeds	èadoe(w)a		Eadu(w)a	E a d u ( w ) a	ɛ a d u ( w ) a						
-122	478	E	schoonhouden, zuiveren; ook: wieden.	keep clean, purify; also: to weed.	èadoö(w)ie		Eado'o(w)i	E a d o ' o ( w ) i	ɛ a d o ʔ o ( w ) i						
-123	478	E	handeling, daad.	act, deed.	èaèkaboe		EaEkabu	E a E k a b u	ɛ a ɛ k a b u						
-124	478	E	zorg, bescherming, hoede; ook: fokken, kweeken	care, protection, guard; also: to breed, to cultivate	èahabaoeda	72	Eahabauda	E a h a b a u d a	ɛ a h a b a u d a						
+122	478	E	schoonhouden , zuiveren ; ook : wieden.	keep clean , purify ; also : to weed.	èadoö(w)ie		Eado'o(w)i	E a d o ' o ( w ) i	ɛ a d o ʔ o ( w ) i						
+123	478	E	handeling , daad.	act , deed.	èaèkaboe		EaEkabu	E a E k a b u	ɛ a ɛ k a b u						
+124	478	E	zorg , bescherming , hoede ; ook : fokken , kweeken	care , protection , guard ; also : to breed , to cultivate	èahabaoeda	72	Eahabauda	E a h a b a u d a	ɛ a h a b a u d a						
 125	478	E	wat ergens voor dient of de sporen draagt van ergens voor gediend te hebben of van afkomstig te zijn	that which serves for something or bears the marks of having served for something or originated from something	èahaboe(w)a		Eahabu(w)a	E a h a b u ( w ) a	ɛ a h a b u ( w ) a						
 126	478	E	zekere papegaaisoort.	certain species of parrot.	èahaie		Eahai	E a h a i	ɛ a h a i						
-127	478	E	oogst, oogsten	harvest, harvesting	èahaienjoqä		Eahaiño'a	E a h a i ñ o ' a	ɛ a h a i ɲ o ʔ a						
+127	478	E	oogst , oogsten	harvest , harvesting	èahaienjoqä		Eahaiño'a	E a h a i ñ o ' a	ɛ a h a i ɲ o ʔ a						
 128	478	E	zich het gelaat en het hoofd wasschen	wash one's face and head	èahaoedohoie		Eahaudohoi	E a h a u d o h o i	ɛ a h a u d o h o i						
 129	478	E	dat wil zeggen	which means	èahèdie(j)a	74	EahEdi(y)a	E a h E d i ( y ) a	ɛ a h ɛ d i ( j ) a						
 130	478	E	ademhaling	breathing	èahoepoq	75	Eahupo'	E a h u p o '	ɛ a h u p o ʔ						
-131	478	E	het op weg afwachten van iemand om hem kwaad te doen, in hinderlaag liggen	waiting for someone on the road to do him harm, lying in ambush	èahopè	76	EahopE	E a h o p E	ɛ a h o p ɛ						
-132	478	E	been, voet, poot	leg, foot, paw	èaie		Eai	E a i	ɛ a i						
-133	478	E	visch. De door den Engganees genuttigde soorten zijn	fish. The species consumed by the Engganese are:	èajo	77	Eayo	E a y o	ɛ a j o						
+131	478	E	het op weg afwachten van iemand om hem kwaad te doen , in hinderlaag liggen	waiting for someone on the road to do him harm , lying in ambush	èahopè	76	EahopE	E a h o p E	ɛ a h o p ɛ						
+132	478	E	been , voet , poot	leg , foot , paw	èaie		Eai	E a i	ɛ a i						
+133	478	E	visch. De door den Engganees genuttigde soorten zijn	fish. The species consumed by the Engganese are : 	èajo	77	Eayo	E a y o	ɛ a j o						
 134	478	E	zeevisch	seafish	èakakoq		Eakako'	E a k a k o '	ɛ a k a k o ʔ						fish species consumed in Enggano at around late 19th century
-135	478	E	zeevisch (die gezouten wordt);	seafish (which is salted);	èanaöa		Eana'oa	E a n a ' o a	ɛ a n a ʔ o a						fish species consumed in Enggano at around late 19th century
-136	479	E	zeevisch (die gezouten wordt);	seafish (which is salted);	èaoeno		Eauno	E a u n o	ɛ a u n o						fish species consumed in Enggano at around late 19th century
+135	478	E	zeevisch (die gezouten wordt) ; 	seafish (which is salted) ; 	èanaöa		Eana'oa	E a n a ' o a	ɛ a n a ʔ o a						fish species consumed in Enggano at around late 19th century
+136	479	E	zeevisch (die gezouten wordt) ; 	seafish (which is salted) ; 	èaoeno		Eauno	E a u n o	ɛ a u n o						fish species consumed in Enggano at around late 19th century
 137	479	E	zeevisch	seafish	èawieka		Eawika	E a w i k a	ɛ a w i k a						fish species consumed in Enggano at around late 19th century
 138	479	E	zeevisch	seafish	èboeboe		Ebubu	E b u b u	ɛ b u b u						fish species consumed in Enggano at around late 19th century
 139	479	E	zeevisch	seafish	èhaie(j)oeĕq		Ehai(y)uė'	E h a i ( y ) u ė '	ɛ h a i ( j ) u ə ʔ						fish species consumed in Enggano at around late 19th century
@@ -147,20 +152,21 @@ ID	page	entry	dutch	english	form	variant_ID	form_common_transcription	form_commo
 146	479	E	zeevisch	seafish	èkapaqie(j)o		Ekapa'i(y)o	E k a p a ' i ( y ) o	ɛ k a p a ʔ i ( j ) o						fish species consumed in Enggano at around late 19th century
 147	479	E	zeevisch	seafish	èkaqoe(w)aie		Eka'u(w)ai	E k a ' u ( w ) a i	ɛ k a ʔ u ( w ) a i						fish species consumed in Enggano at around late 19th century
 148	479	E	zeevisch	seafish	èkieoedahjo		Ekiudahyo	E k i u d a h y o	ɛ k i u d a h j o						fish species consumed in Enggano at around late 19th century
-149	479	E	zeevisch (die gezouten wordt);	seafish (which is salted);	èkieoedie		Ekiudi	E k i u d i	ɛ k i u d i						fish species consumed in Enggano at around late 19th century
+149	479	E	zeevisch (die gezouten wordt) ; 	seafish (which is salted) ; 	èkieoedie		Ekiudi	E k i u d i	ɛ k i u d i						fish species consumed in Enggano at around late 19th century
 150	479	E	zeevisch	seafish	èkietaäpoe(w)aq		Ekita'apu(w)a'	E k i t a ' a p u ( w ) a '	ɛ k i t a ʔ a p u ( w ) a ʔ						fish species consumed in Enggano at around late 19th century
 151	479	E	zeevisch	seafish	èkoe(w)èq		Eku(w)E'	E k u ( w ) E '	ɛ k u ( w ) ɛ ʔ						fish species consumed in Enggano at around late 19th century
-152	479	E	zeevisch (die gezouten wordt);	seafish (which is salted);	èloietjaq		Eloica'	E l o i c a '	ɛ l o i t͡ʃ a ʔ						fish species consumed in Enggano at around late 19th century
-153	479	E	zeevisch (die gezouten wordt);	seafish (which is salted);	èmoenèqä		EmunE'a	E m u n E ' a	ɛ m u n ɛ ʔ a						fish species consumed in Enggano at around late 19th century
-154	479	E	zeevisch (die gezouten wordt)	seafish (which is salted);	èokoödoq		Eoko'odo'	E o k o ' o d o '	ɛ o k o ʔ o d o ʔ						fish species consumed in Enggano at around late 19th century
+152	479	E	zeevisch (die gezouten wordt) ; 	seafish (which is salted) ; 	èloietjaq		Eloica'	E l o i c a '	ɛ l o i t͡ʃ a ʔ						fish species consumed in Enggano at around late 19th century
+153	479	E	zeevisch (die gezouten wordt) ; 	seafish (which is salted) ; 	èmoenèqä		EmunE'a	E m u n E ' a	ɛ m u n ɛ ʔ a						fish species consumed in Enggano at around late 19th century
+154	479	E	zeevisch (die gezouten wordt)	seafish (which is salted) ; 	èokoödoq		Eoko'odo'	E o k o ' o d o '	ɛ o k o ʔ o d o ʔ						fish species consumed in Enggano at around late 19th century
 155	479	E	zeevisch	seafish	èpaoe(w)oko	102	Epau(w)oko	E p a u ( w ) o k o	ɛ p a u ( w ) o k o						fish species consumed in Enggano at around late 19th century
 156	479	E	zoetwatervisch	freshwater fish	èkanawèq		EkanawE'	E k a n a w E '	ɛ k a n a w ɛ ʔ						fish species consumed in Enggano at around late 19th century
 157	479	E	zoetwatervisch	freshwater fish	èkèma		EkEma	E k E m a	ɛ k ɛ m a						fish species consumed in Enggano at around late 19th century
-158	479	E	schillen, onthuiden.	to peel, to skin.	èakadie(j)o		Eakadi(y)o	E a k a d i ( y ) o	ɛ a k a d i ( j ) o						
+158	479	E	schillen , onthuiden.	to peel , to skin.	èakadie(j)o		Eakadi(y)o	E a k a d i ( y ) o	ɛ a k a d i ( j ) o						
 159	479	E	waringin	banyan	èakaka		Eakaka	E a k a k a	ɛ a k a k a						
-160	479	E	een hoofddeksel van rottan, vroeger door de mannen gedurende den rouwtijd gedragen	a headdress made of rattan, previously worn by men during the mourning period	èakakaie		Eakakai	E a k a k a i	ɛ a k a k a i						
+160	479	E	een hoofddeksel van rottan , vroeger door de mannen gedurende den rouwtijd gedragen	a headdress made of rattan , previously worn by men during the mourning period	èakakaie		Eakakai	E a k a k a i	ɛ a k a k a i						
 161	479	E	menstrua	menstruation	èakano		Eakano	E a k a n o	ɛ a k a n o						
-162	479	E	deur, ronde opening in het type Engganeesche woning (bijenkorfvorm), welke nu niet meer wordt aangetroffen;	door, round opening in the Engganese house type (beehive shape), which is no longer found;	è(a)karoba	61	E(a)karoba	E ( a ) k a r o b a	ɛ ( a ) k a r o b a	aroekoe(w)a	aruku(w)a	a r u k u ( w ) a	69 ; 70	a r u k u ( w ) a	sometimes it is è(a)kadoba
+162	479	E	deur , ronde opening in het type Engganeesche woning (bijenkorfvorm) , welke nu niet meer wordt aangetroffen ; 	door , round opening in the Engganese house type (beehive shape) , which is no longer found ; 	è(a)karoba	61	E(a)karoba	E ( a ) k a r o b a	ɛ ( a ) k a r o b a	aroekoe(w)a	aruku(w)a	a r u k u ( w ) a	69	a r u k u ( w ) a	sometimes it is è(a)kadoba
+162	479	E	deur , ronde opening in het type Engganeesche woning (bijenkorfvorm) , welke nu niet meer wordt aangetroffen ; 	door , round opening in the Engganese house type (beehive shape) , which is no longer found ; 	è(a)karoba	61	E(a)karoba	E ( a ) k a r o b a	ɛ ( a ) k a r o b a	aroekoe(w)a	aruku(w)a	a r u k u ( w ) a	70	a r u k u ( w ) a	sometimes it is è(a)kadoba
 163	479	E	zekere zwaluwsoort	certain species of swallow	èakieakie		Eakiaki	E a k i a k i	ɛ a k i a k i						
 164	479	E	kaak	jaw	èakieie		Eakii	E a k i i	ɛ a k i i						
 165	479	E	zekere reigersoort.	certain heron species.	èakomaq		Eakoma'	E a k o m a '	ɛ a k o m a ʔ						
@@ -169,39 +175,39 @@ ID	page	entry	dutch	english	form	variant_ID	form_common_transcription	form_commo
 168	479	E	klapperen van de tanden	chattering of the teeth	èamaniekie		Eamaniki	E a m a n i k i	ɛ a m a n i k i						
 169	479	E	weerhaak aan de Engganeesche lans.	barb on the Engganese lance.	èamè		EamE	E a m E	ɛ a m ɛ						
 170	479	E	schouder	shoulder	èamieamie	79	Eamiami	E a m i a m i	ɛ a m i a m i						
-171	479	E	die, dat	that, that	èana		Eana	E a n a	ɛ a n a						
+171	479	E	die , dat	that , that	èana		Eana	E a n a	ɛ a n a						
 172	479	E	bies	reedmace	èanèka	80	EanEka	E a n E k a	ɛ a n ɛ k a						
 173	480	E	droomen	dream	èanèha	81	EanEha	E a n E h a	ɛ a n ɛ h a						
 174	480	E	in stukken kappen	cut into pieces	èanokanie		Eanokani	E a n o k a n i	ɛ a n o k a n i						
 175	480	E	waterslang	waterhose	èanonöoe		Eanonu̇u	E a n o n u̇ u	ɛ a n o n ɨ u						
-176	480	E	hemel, uitspansel.	heaven, expanse.	èaoedahohoe		Eaudahohu	E a u d a h o h u	ɛ a u d a h o h u						
+176	480	E	hemel , uitspansel.	heaven , expanse.	èaoedahohoe		Eaudahohu	E a u d a h o h u	ɛ a u d a h o h u						
 177	480	E	gebit	teeth	èaoekaä		Eauka'a	E a u k a ' a	ɛ a u k a ʔ a						
-178	480	E	overtreding, misdrijf	offence/violation, crime	èaohaq		Eaoha'	E a o h a '	ɛ a o h a ʔ						
+178	480	E	overtreding , misdrijf	offence/violation , crime	èaohaq		Eaoha'	E a o h a '	ɛ a o h a ʔ						
 179	480	E	met zijn velen wedijveren om iets meester te worden	competing with many to become a master of something	èaokieie		Eaokii	E a o k i i	ɛ a o k i i						
 180	480	E	niezen	sneeze	èapakoe		Eapaku	E a p a k u	ɛ a p a k u						
-181	480	E	zeer veel, eene groote hoeveelheid	very much, a great deal	èapama	67	Eapama	E a p a m a	ɛ a p a m a						
-182	480	E	dik, vet	thick, fat	èapaq	68	Eapa'	E a p a '	ɛ a p a ʔ						
+181	480	E	zeer veel , eene groote hoeveelheid	very much , a great deal	èapama	67	Eapama	E a p a m a	ɛ a p a m a						
+182	480	E	dik , vet	thick , fat	èapaq	68	Eapa'	E a p a '	ɛ a p a ʔ						
 183	480	E	dij	thigh	èapara	66	Eapara	E a p a r a	ɛ a p a r a						
 184	480	E	hand	hand	èapo	69	Eapo	E a p o	ɛ a p o						
-185	480	E	vezel, draad, spier	fiber, thread, muscle	èapoe	70	Eapu	E a p u	ɛ a p u						
-186	480	E	wortel	carrot or root	èapoe èkoe(w)o	71	Eapu Eku(w)o	E a p u # E k u ( w ) o	ɛ a p u # ɛ k u ( w ) o						
-187	480	E	goedgeefsch, mild	benevolent, mild	èapoeaka		Eapuaka	E a p u a k a	ɛ a p u a k a						
+185	480	E	vezel , draad , spier	fiber , thread , muscle	èapoe	70	Eapu	E a p u	ɛ a p u						
+186	480	E	wortel	carrot or root	èapoe_èkoe(w)o	71	Eapu_Eku(w)o	E a p u _ E k u ( w ) o	ɛ a p u _ ɛ k u ( w ) o						
+187	480	E	goedgeefsch , mild	benevolent , mild	èapoeaka		Eapuaka	E a p u a k a	ɛ a p u a k a						
 188	480	E	python	python	èapoeq		Eapu'	E a p u '	ɛ a p u ʔ						
 189	480	E	uitleggers van een vaartuig	a vessel's floats	èapoie		Eapoi	E a p o i	ɛ a p o i						
-190	480	E	die, dat	that, that	èa(q)		Ea(')	E a ( ' )	ɛ a ( ʔ )						
-191	480	E	kind, jong van dieren	child, young of animal	èara		Eara	E a r a	ɛ a r a						
-192	480	E	dochter	daughter	èara: èhöda		Eara: Ehu̇da	E a r a : # E h u̇ d a	ɛ a r a : # ɛ h ɨ d a						
+190	480	E	die , dat	that , that	èa(q)		Ea(')	E a ( ' )	ɛ a ( ʔ )						
+191	480	E	kind , jong van dieren	child , young of animal	èara		Eara	E a r a	ɛ a r a						
+192	480	E	dochter	daughter	èara:_èhöda		Eara:_Ehu̇da	E a r a : _ E h u̇ d a	ɛ a r a : _ ɛ h ɨ d a						
 193	480	E	zoon	son	èmanie	172	Emani	E m a n i	ɛ m a n i						
 194	480	E	gebolsterde rijst	puffed rice	(oe)èkieho		(u)Ekiho	( u ) E k i h o	( u ) ɛ k i ç o						
 195	480	E	ei	egg	(oe)kieadoboe	9	(u)kiadobu	( u ) k i a d o b u	( u ) k i a d o b u						
 196	480	E	eetbaar uitspruitsel van het bamboeriet	edible sprout of the bamboo reed	(oe)wabèha		(u)wabEha	( u ) w a b E h a	( u ) w a b ɛ h a						
 197	480	E	kleine toon	small tone	(oe)äie		(u)'ai	( u ) ' a i	( u ) ʔ a i						
 198	480	E	pink	little finger	(oe)apo	27	(u)apo	( u ) a p o	( u ) a p o						
-199	480	E	bevallen, jongen	give birth, whelp	baära	294	ba'ara	b a ' a r a	b a ʔ a r a						
+199	480	E	bevallen , jongen	give birth , whelp	baära	294	ba'ara	b a ' a r a	b a ʔ a r a						
 200	480	E	erfstuk	heirloom	èaraboeka		Earabuka	E a r a b u k a	ɛ a r a b u k a						
-201	480	E	bloedzweer; melaatschheid	blood ulcer; leprosy	èaraqko(w)a	82	Eara'ko(w)a	E a r a ' k o ( w ) a	ɛ a r a ʔ k o ( w ) a						
+201	480	E	bloedzweer ; melaatschheid	blood ulcer ; leprosy	èaraqko(w)a	82	Eara'ko(w)a	E a r a ' k o ( w ) a	ɛ a r a ʔ k o ( w ) a						
 202	480	E	zekere boomsoort met deugdzaam timmerhout	certain tree species with virtuous lumber	èaroekèrè		EarukErE	E a r u k E r E	ɛ a r u k ɛ r ɛ						
-203	480	E	tellen, rekenen	count, math	èaroe(w)a		Earu(w)a	E a r u ( w ) a	ɛ a r u ( w ) a						
+203	480	E	tellen , rekenen	count , math	èaroe(w)a		Earu(w)a	E a r u ( w ) a	ɛ a r u ( w ) a						
 204	480	E	de vezelige bast van de kokosnoot	the fibrous bark of the coconut	èaroja		Earoya	E a r o y a	ɛ a r o j a						
 205	480	E	oksel	armpit	èaropa	78	Earopa	E a r o p a	ɛ a r o p a						
 206	480	E	kreng	bitch	èaroqä		Earo'a	E a r o ' a	ɛ a r o ʔ a						
@@ -213,22 +219,22 @@ ID	page	entry	dutch	english	form	variant_ID	form_common_transcription	form_commo
 212	480	E	hart	heart	èbaho		Ebaho	E b a h o	ɛ b a h o						
 213	480	E	komen	come	èbaie		Ebai	E b a i	ɛ b a i						
 214	480	E	oog	eye	èbaka		Ebaka	E b a k a	ɛ b a k a						
-215	480	E	openingen tusschen de reven, welke een doorgang vormen voor de vaartuigen	openings between the reefs, which provide a passage for vessels	èbaka: (è)oewè	84	Ebaka: (E)uwE	E b a k a : # ( E ) u w E	ɛ b a k a : # ( ɛ ) u w ɛ						
+215	480	E	openingen tusschen de reven , welke een doorgang vormen voor de vaartuigen	openings between the reefs , which provide a passage for vessels	èbaka:_(è)oewè	84	Ebaka:_(E)uwE	E b a k a : _ ( E ) u w E	ɛ b a k a : _ ( ɛ ) u w ɛ						
 216	481	E	zon	sun	(oe)kahaoq		(u)kahao'	( u ) k a h a o '	( u ) k a h a o ʔ						
-217	481	E	maagholte, maag	stomach cavity, stomach	(oe)kiedjaie	391	(u)kijai	( u ) k i j a i	( u ) k i d͡ʒ a i						
+217	481	E	maagholte , maag	stomach cavity , stomach	(oe)kiedjaie	391	(u)kijai	( u ) k i j a i	( u ) k i d͡ʒ a i						
 218	481	E	tepel	nipple	(oe)kokoq		(u)koko'	( u ) k o k o '	( u ) k o k o ʔ						
 219	481	E	zwavelstok	sulphur stick	(oe)oemo		(u)umo	( u ) u m o	( u ) u m o						
 220	481	E	zekere pisangsoort	certain species of pisang	èbaoe		Ebau	E b a u	ɛ b a u						
-221	481	E	rivier; ook: de monding van eene rivier zoowel in zee als in eene andere rivier	river; also: the mouth of a river both in the sea and in another river	èbèlo(w)a		EbElo(w)a	E b E l o ( w ) a	ɛ b ɛ l o ( w ) a						
+221	481	E	rivier ; ook : de monding van eene rivier zoowel in zee als in eene andere rivier	river ; also : the mouth of a river both in the sea and in another river	èbèlo(w)a		EbElo(w)a	E b E l o ( w ) a	ɛ b ɛ l o ( w ) a						
 222	481	E	hond	dog	èbèo		EbEo	E b E o	ɛ b ɛ o						
-223	481	E	wesp, bij	wasp, bee	èbiehoe		Ebihu	E b i h u	ɛ b i ç u						
+223	481	E	wesp , bij	wasp , bee	èbiehoe		Ebihu	E b i h u	ɛ b i ç u						
 224	481	E	kleine zwarte torretjes in hout en granen	small black beetles in wood and cereals	èbie(j)oe		Ebi(y)u	E b i ( y ) u	ɛ b i ( j ) u						
-225	481	E	water, regen	water, rain	èbo		Ebo	E b o	ɛ b o						
-226	481	E	oplettend, voorzichtig	watchful, careful	èboeèparaqwo	85	EbuEpara'wo	E b u E p a r a ' w o	ɛ b u ɛ p a r a ʔ w o						
+225	481	E	water , regen	water , rain	èbo		Ebo	E b o	ɛ b o						
+226	481	E	oplettend , voorzichtig	watchful , careful	èboeèparaqwo	85	EbuEpara'wo	E b u E p a r a ' w o	ɛ b u ɛ p a r a ʔ w o						
 227	481	E	part. pud. masc.	part. pud. masc.	èboe(w)è		Ebu(w)E	E b u ( w ) E	ɛ b u ( w ) ɛ						
-228	481	E	pompoen, kalebas	pumpkin, gourd	èboqaboqa	86	Ebo'abo'a	E b o ' a b o ' a	ɛ b o ʔ a b o ʔ a						
-229	481	E	rechts, rechter, de rechterzijde	on the right, right, the right side	èdaba	160	Edaba	E d a b a	ɛ d a b a						
-230	481	E	ziek, ziekte, pijn	sick, disease, pain	èdaboeho	230	Edabuho	E d a b u h o	ɛ d a b u h o						
+228	481	E	pompoen , kalebas	pumpkin , gourd	èboqaboqa	86	Ebo'abo'a	E b o ' a b o ' a	ɛ b o ʔ a b o ʔ a						
+229	481	E	rechts , rechter , de rechterzijde	on the right , right , the right side	èdaba	160	Edaba	E d a b a	ɛ d a b a						
+230	481	E	ziek , ziekte , pijn	sick , disease , pain	èdaboeho	230	Edabuho	E d a b u h o	ɛ d a b u h o						
 231	481	E	koorts	fever	èdaboeho	231	Edabuho	E d a b u h o	ɛ d a b u h o						
 232	481	E	koorts	fever	èadoho		Eadoho	E a d o h o	ɛ a d o h o						
 233	481	E	venerische ziekte	veneral disease	èaroiepoko		Earoipoko	E a r o i p o k o	ɛ a r o i p o k o						
@@ -239,191 +245,195 @@ ID	page	entry	dutch	english	form	variant_ID	form_common_transcription	form_commo
 238	481	E	hoofdpijn	headache	èoedoe	193	Eudu	E u d u	ɛ u d u						
 239	481	E	kiespijn	toothache	èoekaq		Euka'	E u k a '	ɛ u k a ʔ						
 240	481	E	beri-beri	beri-beri	èpaö		Epa'o	E p a ' o	ɛ p a ʔ o						
-241	481	E	hoofdkussen	pillow	èdado; èdadoèoedoe	194	Edado; Edaduudu	E d a d o ; # E d a d u u d u	ɛ d a d o ; # ɛ d a d u u d u						
+241	481	E	hoofdkussen	pillow	èdado	194	Edado	E d a d o	ɛ d a d o						
+241	481	E	hoofdkussen	pillow	èdadoèoedoe	194	Edaduudu	E d a d u u d u	ɛ d a d u u d u						
 242	481	E	leguaan	iguana	èdahajo	161	Edahayo	E d a h a y o	ɛ d a h a j o						
 243	481	E	getrouwde vrouw	married woman	èdahèboeäo	163	EdahEbu'ao	E d a h E b u ' a o	ɛ d a h ɛ b u ʔ a o						
 244	481	E	hevige storm	violent storm	èdakohaq		Edakoha'	E d a k o h a '	ɛ d a k o h a ʔ						
 245	481	E	persoonlijke vijand	personal enemy	èdèabo	164	EdEabo	E d E a b o	ɛ d ɛ a b o						
-246	481	E	bijten van slangen; schaar van kreeften	snake bites; lobster pincers	èdiehao	89	Edihao	E d i h a o	ɛ d i ç a o						
+246	481	E	bijten van slangen ; schaar van kreeften	snake bites ; lobster pincers	èdiehao	89	Edihao	E d i h a o	ɛ d i ç a o						
 247	481	E	oud kreupelbosch	old coppice	èdiehie(j)oq		Edihi(y)o'	E d i h i ( y ) o '	ɛ d i ç i ( j ) o ʔ						
 248	481	E	aardbeving	earthquake	èdieho	227	Ediho	E d i h o	ɛ d i ç o						
 249	481	E	etter	pus	èdie(j)a	87	Edi(y)a	E d i ( y ) a	ɛ d i ( j ) a						
-250	481	E	tong, speeksel	tongue, saliva	èdie(j)o	165	Edi(y)o	E d i ( y ) o	ɛ d i ( j ) o						
-251	481	E	tong, speeksel	tongue, saliva	èdieie(j)o	166	Edii(y)o	E d i i ( y ) o	ɛ d i i ( j ) o						
+250	481	E	tong , speeksel	tongue , saliva	èdie(j)o	165	Edi(y)o	E d i ( y ) o	ɛ d i ( j ) o						
+251	481	E	tong , speeksel	tongue , saliva	èdieie(j)o	166	Edii(y)o	E d i i ( y ) o	ɛ d i i ( j ) o						
 252	481	E	beraadslaging	deliberation	èdie(j)oe(w)aka		Edi(y)u(w)aka	E d i ( y ) u ( w ) a k a	ɛ d i ( j ) u ( w ) a k a						
-253	481	E	voornemen, plan, bedoeling	intention, plan, intention	èdie(j)oewaoekèdjajoe		Edi(y)uwaukEjayu	E d i ( y ) u w a u k E j a y u	ɛ d i ( j ) u w a u k ɛ d͡ʒ a j u						
+253	481	E	voornemen , plan , bedoeling	intention , plan , intention	èdie(j)oewaoekèdjajoe		Edi(y)uwaukEjayu	E d i ( y ) u w a u k E j a y u	ɛ d i ( j ) u w a u k ɛ d͡ʒ a j u						
 254	481	E	geroost	toasted	èdiekieho		Edikiho	E d i k i h o	ɛ d i k i ç o						
 255	481	E	lichtstraal	light beam	èdiekoeroe		Edikuru	E d i k u r u	ɛ d i k u r u						
-256	481	E	dat is zijn werk, dat hebben wij aan hem te danken	this is his work, we owe it to him	èdieoboe; èdieoboedie(j)ĕ		Ediobu; Ediobudi(y)ė	E d i o b u ; # E d i o b u d i ( y ) ė	ɛ d i o b u ; # ɛ d i o b u d i ( j ) ə						
-257	481	E	goederen, rijkdom	goods, wealth	èdoboe	167	Edobu	E d o b u	ɛ d o b u						
-258	481	E	erfgoederen	heritage	èdoboe kanapoe(w)a	168	Edobu kanapu(w)a	E d o b u # k a n a p u ( w ) a	ɛ d o b u # k a n a p u ( w ) a						
-259	481	E	stroom in eene rivier, bandjir	stream in a river, flooding	èdodie	90	Edodi	E d o d i	ɛ d o d i						
+256	481	E	dat is zijn werk , dat hebben wij aan hem te danken	this is his work , we owe it to him	èdieoboe		Ediobu	E d i o b u	ɛ d i o b u						
+256	481	E	dat is zijn werk , dat hebben wij aan hem te danken	this is his work , we owe it to him	èdieoboedie(j)ĕ		Ediobudi(y)ė	E d i o b u d i ( y ) ė	ɛ d i o b u d i ( j ) ə						
+257	481	E	goederen , rijkdom	goods , wealth	èdoboe	167	Edobu	E d o b u	ɛ d o b u						
+258	481	E	erfgoederen	heritage	èdoboe_kanapoe(w)a	168	Edobu_kanapu(w)a	E d o b u _ k a n a p u ( w ) a	ɛ d o b u _ k a n a p u ( w ) a						
+259	481	E	stroom in eene rivier , bandjir	stream in a river , flooding	èdodie	90	Edodi	E d o d i	ɛ d o d i						
 260	481	E	lucifer	match	èdoehoekie(j)aq	228	Eduhuki(y)a'	E d u h u k i ( y ) a '	ɛ d u h u k i ( j ) a ʔ						
 261	481	E	droog van het jaargetijde	dry of the season	èdohaie	183	Edohai	E d o h a i	ɛ d o h a i						
-262	482	E	hooren, met de ooren vernemen, hooren kunnen	hear, perceive with ears, be able to hear	èdohoie	88	Edohoi	E d o h o i	ɛ d o h o i						
-263	482	E	getuige, ooggetuige	witness, eyewitness	kiedohoie	342	kidohoi	k i d o h o i	k i d o h o i						
+262	482	E	hooren , met de ooren vernemen , hooren kunnen	hear , perceive with ears , be able to hear	èdohoie	88	Edohoi	E d o h o i	ɛ d o h o i						
+263	482	E	getuige , ooggetuige	witness , eyewitness	kiedohoie	342	kidohoi	k i d o h o i	k i d o h o i						
 264	482	E	kleine glaskoralen van allerlei kleur	small glass corals of all kinds of color	èdolèdolè	170	EdolEdolE	E d o l E d o l E	ɛ d o l ɛ d o l ɛ						
-265	482	E	vallei, landstreek	valley, tract	èdoöa		Edo'oa	E d o ' o a	ɛ d o ʔ o a						
-266	482	E	zand, zandbank	sand, sandbank	èdoöraoe		Edo'orau	E d o ' o r a u	ɛ d o ʔ o r a u						
-267	482	E	wat beneden is, benedendeel, onderlaag	what is below, lower part, underlayer	èdopo	280	Edopo	E d o p o	ɛ d o p o						
+265	482	E	vallei , landstreek	valley , tract	èdoöa		Edo'oa	E d o ' o a	ɛ d o ʔ o a						
+266	482	E	zand , zandbank	sand , sandbank	èdoöraoe		Edo'orau	E d o ' o r a u	ɛ d o ʔ o r a u						
+267	482	E	wat beneden is , benedendeel , onderlaag	what is below , lower part , underlayer	èdopo	280	Edopo	E d o p o	ɛ d o p o						
 268	482	E	parasiet (plant)	parasite (plant)	èdopodopo	229	Edopodopo	E d o p o d o p o	ɛ d o p o d o p o						
 269	482	E	met den stroom of den wind wegdrijven	drifting away with the stream or wind	èdoro	171	Edoro	E d o r o	ɛ d o r o						
 270	482	E	part. pud. fem.	part. pud. fem.	èè		EE	E E	ɛ ɛ						
 271	482	E	een cassavesoort	a cassava species	èèbaè		EEbaE	E E b a E	ɛ ɛ b a ɛ						
 272	482	E	stamper van steen	pestle of stone	èèdako	93	EEdako	E E d a k o	ɛ ɛ d a k o	èpahjoe	Epahyu	E p a h y u	624	ɛ p a h j u	
-273	482	E	zekere boomsoort, waarvan de bast, na geklopt te zijn, voor het vervaardigen van kleedingstukken wordt gebezigd	certain species of tree, the bark of which, after being beaten, is used for making garments	èèèno		EEEno	E E E n o	ɛ ɛ ɛ n o						
-274	482	E	hoest, hoesten	cough, cough	èèhè		EEhE	E E h E	ɛ ɛ h ɛ						
-275	482	E	hoe, wat	how, what	èèho		EEho	E E h o	ɛ ɛ h o						
-276	482	E	koud, koude	cold, cold	èèhöa		EEhu̇a	E E h u̇ a	ɛ ɛ h ɨ a						
-277	482	E	koraalrif, koraalbank	coral reef, coral bank	èè(j)aq		EE(y)a'	E E ( y ) a '	ɛ ɛ ( j ) a ʔ						
+273	482	E	zekere boomsoort , waarvan de bast , na geklopt te zijn , voor het vervaardigen van kleedingstukken wordt gebezigd	certain species of tree , the bark of which , after being beaten , is used for making garments	èèèno		EEEno	E E E n o	ɛ ɛ ɛ n o						
+274	482	E	hoest , hoesten	cough , cough	èèhè		EEhE	E E h E	ɛ ɛ h ɛ						
+275	482	E	hoe , wat	how , what	èèho		EEho	E E h o	ɛ ɛ h o						
+276	482	E	koud , koude	cold , cold	èèhöa		EEhu̇a	E E h u̇ a	ɛ ɛ h ɨ a						
+277	482	E	koraalrif , koraalbank	coral reef , coral bank	èè(j)aq		EE(y)a'	E E ( y ) a '	ɛ ɛ ( j ) a ʔ						
 278	482	E	zijn gevoeg doen	do his bidding	èèkadjie(j)a		EEkaji(y)a	E E k a j i ( y ) a	ɛ ɛ k a d͡ʒ i ( j ) a						
-279	482	E	urine, urineeren	urine, urinate	èèko		EEko	E E k o	ɛ ɛ k o						
-280	482	E	weenen, tranen storten	weep, shed tears	èèlo		EElo	E E l o	ɛ ɛ l o						
+279	482	E	urine , urineeren	urine , urinate	èèko		EEko	E E k o	ɛ ɛ k o						
+280	482	E	weenen , tranen storten	weep , shed tears	èèlo		EElo	E E l o	ɛ ɛ l o						
 281	482	E	dakspar	rafter	èèmaha		EEmaha	E E m a h a	ɛ ɛ m a h a						
 282	482	E	schubben van dieren en planten	scales of animals and plants	èèna		EEna	E E n a	ɛ ɛ n a						
 283	482	E	dadap (boomsoort)	dadap (tree species)	èènèho		EEnEho	E E n E h o	ɛ ɛ n ɛ h o						
-284	482	E	de taaie bladscheede van den betelnootpalm	the tough leaf sheath of the betel nut palm	èènono; èènono: oepo	95	EEnono; EEnono: upo	E E n o n o ; # E E n o n o : # u p o	ɛ ɛ n o n o ; # ɛ ɛ n o n o : # u p o						
+284	482	E	de taaie bladscheede van den betelnootpalm	the tough leaf sheath of the betel nut palm	èènono	95	EEnono	E E n o n o	ɛ ɛ n o n o						
+284	482	E	de taaie bladscheede van den betelnootpalm	the tough leaf sheath of the betel nut palm	èènono:_oepo	95	EEnono:_upo	E E n o n o : _ u p o	ɛ ɛ n o n o : _ u p o						
 285	482	E	de taaie bladscheede van den niboengpalm	the tough leaf sheath of the nibung palm	oeèpo	430	uEpo	u E p o	u ɛ p o						
-286	482	E	vel, dop, schil	skin, shell	èèodie	96	EEodi	E E o d i	ɛ ɛ o d i						
+286	482	E	vel , dop , schil	skin , shell	èèodie	96	EEodi	E E o d i	ɛ ɛ o d i						
 287	482	E	schors	bark	èèodieoekoewo	97	EEodiukuwo	E E o d i u k u w o	ɛ ɛ o d i u k u w o						
-288	482	E	ergens wegleggen of weggelegd hebben om het te bewaren, bewaren, plaatsen, neerzetten	put away or have put away somewhere to keep it, keep, place, put down	èèoq		EEo'	E E o '	ɛ ɛ o ʔ						
-289	482	E	links, de linkerzijde	left, the left side	èèpè		EEpE	E E p E	ɛ ɛ p ɛ						
-290	482	E	niboeng, gekloofde niboenglat voor bevloering	nibung, cleft nibung slat for flooring	èèpo	92	EEpo	E E p o	ɛ ɛ p o						
+288	482	E	ergens wegleggen of weggelegd hebben om het te bewaren , bewaren , plaatsen , neerzetten	put away or have put away somewhere to keep it , keep , place , put down	èèoq		EEo'	E E o '	ɛ ɛ o ʔ						
+289	482	E	links , de linkerzijde	left , the left side	èèpè		EEpE	E E p E	ɛ ɛ p ɛ						
+290	482	E	niboeng , gekloofde niboenglat voor bevloering	nibung , cleft nibung slat for flooring	èèpo	92	EEpo	E E p o	ɛ ɛ p o						
 291	482	E	eene rustbank van hout	a resting bench of wood	èhabarie(j)a	114	Ehabari(y)a	E h a b a r i ( y ) a	ɛ h a b a r i ( j ) a						
 292	482	E	worm	worm	èhado(q)		Ehado(')	E h a d o ( ' )	ɛ h a d o ( ʔ )						
-293	482	E	draai, kronkel	twist, turn	èhahadiediekie		Ehahadidiki	E h a h a d i d i k i	ɛ h a h a d i d i k i						
+293	482	E	draai , kronkel	twist , turn	èhahadiediekie		Ehahadidiki	E h a h a d i d i k i	ɛ h a h a d i d i k i						
 294	482	E	omkappen van hoogstammig geboomte	felling of tall trees	èhaiepoe	117	Ehaipu	E h a i p u	ɛ h a i p u						
 295	482	E	vlucht van vogels	flight of birds	èhamo		Ehamo	E h a m o	ɛ h a m o						
 296	482	E	vliegen	fly	kiehahamo		kihahamo	k i h a h a m o	k i ç a h a m o						
-297	482	E	ijlen, hardop droomen	delirious, dreaming out loud	èhamoa		Ehamoa	E h a m o a	ɛ h a m o a						
+297	482	E	ijlen , hardop droomen	delirious , dreaming out loud	èhamoa		Ehamoa	E h a m o a	ɛ h a m o a						
 298	483	E	hals	neck	èhanoe(w)a		Ehanu(w)a	E h a n u ( w ) a	ɛ h a n u ( w ) a						
 299	483	E	stookplaats	fireplace	èhao	116	Ehao	E h a o	ɛ h a o						
-300	483	E	woelen, krauwelen in het haar	burrow, clawing in hair	èharobèao		EharobEao	E h a r o b E a o	ɛ h a r o b ɛ a o						
-301	483	E	hebben, bezitten	have, possess	èharoeq		Eharu'	E h a r u '	ɛ h a r u ʔ						
+300	483	E	woelen , krauwelen in het haar	burrow , clawing in hair	èharobèao		EharobEao	E h a r o b E a o	ɛ h a r o b ɛ a o						
+301	483	E	hebben , bezitten	have , possess	èharoeq		Eharu'	E h a r u '	ɛ h a r u ʔ						
 302	483	E	groot zwaard	great sword	èhèapo	118	EhEapo	E h E a p o	ɛ h ɛ a p o						
 303	483	E	minnelied	love song	èhèboe		EhEbu	E h E b u	ɛ h ɛ b u						
 304	483	E	broeder of zuster	brother or sister	èhèie(j)o	119	EhEi(y)o	E h E i ( y ) o	ɛ h ɛ i ( j ) o						
-305	483	E	trap (eertijds een schuin in den grond geplaatsten boomstam, waarin treden zijn gekapt)	stairs (formerly a tree trunk set into the ground at an angle, into which steps were cut)	èhèja		EhEya	E h E y a	ɛ h ɛ j a						
-306	483	E	zitten, gezeten zijn, gaan zitten	sit, be seated, sit down	èhèkoe(q)	115	EhEku(')	E h E k u ( ' )	ɛ h ɛ k u ( ʔ )						
-307	483	E	zitten, gezeten zijn, gaan zitten	to sit, to be seated, to sit	mahèkoe(q)	410	mahEku(')	m a h E k u ( ' )	m a h ɛ k u ( ʔ )						
+305	483	E	trap (eertijds een schuin in den grond geplaatsten boomstam , waarin treden zijn gekapt)	stairs (formerly a tree trunk set into the ground at an angle , into which steps were cut)	èhèja		EhEya	E h E y a	ɛ h ɛ j a						
+306	483	E	zitten , gezeten zijn , gaan zitten	sit , be seated , sit down	èhèkoe(q)	115	EhEku(')	E h E k u ( ' )	ɛ h ɛ k u ( ʔ )						
+307	483	E	zitten , gezeten zijn , gaan zitten	to sit , to be seated , to sit	mahèkoe(q)	410	mahEku(')	m a h E k u ( ' )	m a h ɛ k u ( ʔ )						
 308	483	E	roeibank	rowing bench	èhèkoe(q)wa	120	EhEku(')wa	E h E k u ( ' ) w a	ɛ h ɛ k u ( ʔ ) w a						
-309	483	E	vol, gevuld	full, filled	èhèla		EhEla	E h E l a	ɛ h ɛ l a						
-310	483	E	ledig, waar niet in is	empty, in which there is nothing	kèo hèla		kEo hEla	k E o # h E l a	k ɛ o # h ɛ l a						
+309	483	E	vol , gevuld	full , filled	èhèla		EhEla	E h E l a	ɛ h ɛ l a						
+310	483	E	ledig , waar niet in is	empty , in which there is nothing	kèo_hèla		kEo_hEla	k E o _ h E l a	k ɛ o _ h ɛ l a						
 311	483	E	vrucht	fruit	èhèoe(w)a		EhEu(w)a	E h E u ( w ) a	ɛ h ɛ u ( w ) a						
 312	483	E	korrel	grain	èhèoe(w)è		EhEu(w)E	E h E u ( w ) E	ɛ h ɛ u ( w ) ɛ						
 313	483	E	jongere broeder of zuster	younger brother or sister	èhè(q)ie(j)oe		EhE(')i(y)u	E h E ( ' ) i ( y ) u	ɛ h ɛ ( ʔ ) i ( j ) u						
-314	483	E	kust, strand	coast, beach	èhèrie(j)a		EhEri(y)a	E h E r i ( y ) a	ɛ h ɛ r i ( j ) a						
-315	483	E	wat, welk	what, which	èhie(j)o		Ehi(y)o	E h i ( y ) o	ɛ h i ( j ) o						
+314	483	E	kust , strand	coast , beach	èhèrie(j)a		EhEri(y)a	E h E r i ( y ) a	ɛ h ɛ r i ( j ) a						
+315	483	E	wat , welk	what , which	èhie(j)o		Ehi(y)o	E h i ( y ) o	ɛ h i ( j ) o						
 316	483	E	asch	ash	èhoa		Ehoa	E h o a	ɛ h o a						
 317	483	E	bezem	broom	èhöadie	123	Ehu̇adi	E h u̇ a d i	ɛ h ɨ a d i						
 318	483	E	vegen	sweep	mahöadie	411	mahu̇adi	m a h u̇ a d i	m a h ɨ a d i						
 319	483	E	vliegende hond	flying dog	èhoanie		Ehoani	E h o a n i	ɛ h o a n i						
 320	483	E	palm van de hand	palm of the hand	èho(w)apo	122	Eho(w)apo	E h o ( w ) a p o	ɛ h o ( w ) a p o						
-321	483	E	zekere boomsoort, waarvan de bast, na geklopt te zijn, gebezigd wordt voor het vervaardigen van kleedingstukken	certain species of tree, the bark of which, after being beaten, is used to make garments	èhoboe		Ehobu	E h o b u	ɛ h o b u	èèèno	EEEno	E E E n o	273	ɛ ɛ ɛ n o	
+321	483	E	zekere boomsoort , waarvan de bast , na geklopt te zijn , gebezigd wordt voor het vervaardigen van kleedingstukken	certain species of tree , the bark of which , after being beaten , is used to make garments	èhoboe		Ehobu	E h o b u	ɛ h o b u	èèèno	EEEno	E E E n o	273	ɛ ɛ ɛ n o	
 322	483	E	vrouwelijk	female	èhöda		Ehu̇da	E h u̇ d a	ɛ h ɨ d a						
-323	483	E	luis, vloo	louse, flea	èhoekoe		Ehuku	E h u k u	ɛ h u k u						
+323	483	E	luis , vloo	louse , flea	èhoekoe		Ehuku	E h u k u	ɛ h u k u						
 324	483	E	slak	snail	èhoe(w)a		Ehu(w)a	E h u ( w ) a	ɛ h u ( w ) a						
-325	483	E	snijden, afsnijden, slachten	cutting, cutting off, slaughtering	èhoka		Ehoka	E h o k a	ɛ h o k a						
-326	483	E	achterste van menschen (ook van dieren); anus	hindquarters/rear/behind of humans (including animals); anus	èhokaie		Ehokai	E h o k a i	ɛ h o k a i						
+325	483	E	snijden , afsnijden , slachten	cutting , cutting off , slaughtering	èhoka		Ehoka	E h o k a	ɛ h o k a						
+326	483	E	achterste van menschen (ook van dieren) ; anus	hindquarters/rear/behind of humans (including animals) ; anus	èhokaie		Ehokai	E h o k a i	ɛ h o k a i						
 327	483	E	kakkerlak	cockroach	èhoka(q)		Ehoka(')	E h o k a ( ' )	ɛ h o k a ( ʔ )						
-328	483	E	overgebleven stomp, afgehouwen stuk, afgesneden stuk, snijden, afsnijden	remaining stump, cut off piece, severed piece, cutting, cutting off	èhokoe		Ehoku	E h o k u	ɛ h o k u						
-329	483	E	gat, kuil	hole, pit	èhopo		Ehopo	E h o p o	ɛ h o p o						
+328	483	E	overgebleven stomp , afgehouwen stuk , afgesneden stuk , snijden , afsnijden	remaining stump , cut off piece , severed piece , cutting , cutting off	èhokoe		Ehoku	E h o k u	ɛ h o k u						
+329	483	E	gat , kuil	hole , pit	èhopo		Ehopo	E h o p o	ɛ h o p o						
 330	483	E	inktvisch	squid	èhoqä		Eho'a	E h o ' a	ɛ h o ʔ a						
 331	483	E	dans en zang bij het kalèakoebaba feest	dance and song at the kalèakoebaba festival	èhora		Ehora	E h o r a	ɛ h o r a						
 332	483	E	zool van den voet	sole of the foot	èhowaie		Ehowai	E h o w a i	ɛ h o w a i						
-333	483	E	deze, dit	these, this	èie		Ei	E i	ɛ i						
-334	483	E	vermetel, moedig, stout; ook: norsch, wild, grimmig, geen tegenspraak kunnen verdragen, slecht, kwaad, iemand kwaad doen	audacious, brave, naughty; also: gruff, wild, grim, unable to bear contradiction, bad, evil, hurting someone	èieboe		Eibu	E i b u	ɛ i b u						
-335	484	E	geluid, stem, het zeggen, wat door iemand gezegd wordt, iemands woorden, gezegde, raad, raadpleging, oordeel	sound, voice, saying, what is said by someone, someone's words, saying, advice, consultation, judgement	èiedjie	91	Eiji	E i j i	ɛ i d͡ʒ i						
-336	484	E	antwoord, antwoorden, antwoord geven	answer, answering, answering	aiedjie	24	aiji	a i j i	a i d͡ʒ i						
-337	484	E	wat, welke	what, which	èieha		Eiha	E i h a	ɛ i ç a						
-338	484	E	spijker, nagel, pen, speld, naald	nail, nail, pen, pin, needle	èieie		Eii	E i i	ɛ i i						
+333	483	E	deze , dit	these , this	èie		Ei	E i	ɛ i						
+334	483	E	vermetel , moedig , stout ; ook : norsch , wild , grimmig , geen tegenspraak kunnen verdragen , slecht , kwaad , iemand kwaad doen	audacious , brave , naughty ; also : gruff , wild , grim , unable to bear contradiction , bad , evil , hurting someone	èieboe		Eibu	E i b u	ɛ i b u						
+335	484	E	geluid , stem , het zeggen , wat door iemand gezegd wordt , iemands woorden , gezegde , raad , raadpleging , oordeel	sound , voice , saying , what is said by someone , someone's words , saying , advice , consultation , judgement	èiedjie	91	Eiji	E i j i	ɛ i d͡ʒ i						
+336	484	E	antwoord , antwoorden , antwoord geven	answer , answering , answering	aiedjie	24	aiji	a i j i	a i d͡ʒ i						
+337	484	E	wat , welke	what , which	èieha		Eiha	E i h a	ɛ i ç a						
+338	484	E	spijker , nagel , pen , speld , naald	nail , nail , pen , pin , needle	èieie		Eii	E i i	ɛ i i						
 339	484	E	een haarspeld van bamboe	a hairpin made of bamboo	èieieoedoe	126	Eiiudu	E i i u d u	ɛ i i u d u						
 340	484	E	zekere vogelsoort.	certain species of bird.	èie(j)aoe		Ei(y)au	E i ( y ) a u	ɛ i ( j ) a u	béo	beo	b e o	Malay crossref	b e o	
-341	484	E	bedeksel van uitgerafelde pisang- of rottanbladeren, eertijds door de vrouwen gedurende den rouwtijd gedragen	cover of frayed pisang or rottan leaves, formerly worn by women during the mourning period	èie(j)ĕ		Ei(y)ė	E i ( y ) ė	ɛ i ( j ) ə						
+341	484	E	bedeksel van uitgerafelde pisang- of rottanbladeren , eertijds door de vrouwen gedurende den rouwtijd gedragen	cover of frayed pisang or rottan leaves , formerly worn by women during the mourning period	èie(j)ĕ		Ei(y)ė	E i ( y ) ė	ɛ i ( j ) ə						
 342	484	E	zekere boomsoort met deugdzaam timmerhout	certain tree species with decent lumber	èie(j)oba	124	Ei(y)oba	E i ( y ) o b a	ɛ i ( j ) o b a						
-343	484	E	dier, beest in tegenstelling van andere wezens	animal, beast as opposed to other creatures	èie(j)oedopo		Ei(y)udopo	E i ( y ) u d o p o	ɛ i ( j ) u d o p o						
+343	484	E	dier , beest in tegenstelling van andere wezens	animal , beast as opposed to other creatures	èie(j)oedopo		Ei(y)udopo	E i ( y ) u d o p o	ɛ i ( j ) u d o p o						
 344	484	E	groot werpnet in gebruik bij de zeevischvangst	large casting net used in sea fishing	èie(j)oöboöie		Ei(y)o'obo'oi	E i ( y ) o ' o b o ' o i	ɛ i ( j ) o ʔ o b o ʔ o i						
-345	484	E	lang, lengte	long, length	èienoeqoe(q)		Einu'u(')	E i n u ' u ( ' )	ɛ i n u ʔ u ( ʔ )	amoehoe	amuhu	a m u h u	47	a m u h u	
+345	484	E	lang , lengte	long , length	èienoeqoe(q)		Einu'u(')	E i n u ' u ( ' )	ɛ i n u ʔ u ( ʔ )	amoehoe	amuhu	a m u h u	47	a m u h u	
 346	484	E	eene reeds brandende toorts	an already burning torch	èienoeqoeie		Einu'ui	E i n u ' u i	ɛ i n u ʔ u i						
 347	484	E	rook	smoke	èiepo	125	Eipo	E i p o	ɛ i p o						
 348	484	E	zekere rottansoort	certain rottan species	èietjo		Eico	E i c o	ɛ i t͡ʃ o						
-349	484	E	fijn snijden, tot iets snijden	finely cut, cut into something	è(j)adamaie		E(y)adamai	E ( y ) a d a m a i	ɛ ( j ) a d a m a i						
-350	484	E	plaats, verblijfplaats	place, abode	è(j)aha		E(y)aha	E ( y ) a h a	ɛ ( j ) a h a						
-351	484	E	leven, ziel	life, soul	è(j)ahakoqie		E(y)ahako'i	E ( y ) a h a k o ' i	ɛ ( j ) a h a k o ʔ i						
-352	484	E	dammarkaars, lamp	dammar candle, lamp	è(j)ahaoeobie		E(y)ahauobi	E ( y ) a h a u o b i	ɛ ( j ) a h a u o b i						
-353	484	E	wetten, aanzetten	sharpen, turn on / instigate	è(j)ahèaqaq		E(y)ahEa'a'	E ( y ) a h E a ' a '	ɛ ( j ) a h ɛ a ʔ a ʔ						
+349	484	E	fijn snijden , tot iets snijden	finely cut , cut into something	è(j)adamaie		E(y)adamai	E ( y ) a d a m a i	ɛ ( j ) a d a m a i						
+350	484	E	plaats , verblijfplaats	place , abode	è(j)aha		E(y)aha	E ( y ) a h a	ɛ ( j ) a h a						
+351	484	E	leven , ziel	life , soul	è(j)ahakoqie		E(y)ahako'i	E ( y ) a h a k o ' i	ɛ ( j ) a h a k o ʔ i						
+352	484	E	dammarkaars , lamp	dammar candle , lamp	è(j)ahaoeobie		E(y)ahauobi	E ( y ) a h a u o b i	ɛ ( j ) a h a u o b i						
+353	484	E	wetten , aanzetten	sharpen , turn on / instigate	è(j)ahèaqaq		E(y)ahEa'a'	E ( y ) a h E a ' a '	ɛ ( j ) a h ɛ a ʔ a ʔ						
 354	484	E	litteeken	scar	è(j)akoqä		E(y)ako'a	E ( y ) a k o ' a	ɛ ( j ) a k o ʔ a						
 355	484	E	bijleggen van een geschil	settling of a dispute	è(j)akoro(w)a		E(y)akoro(w)a	E ( y ) a k o r o ( w ) a	ɛ ( j ) a k o r o ( w ) a						
-356	484	E			è(j)aniemaie	38	E(y)animai	E ( y ) a n i m a i	ɛ ( j ) a n i m a i	aniemaie	animai	a n i m a i	51 ; 684	a n i m a i	
-357	484	E	in het verderf gestort, verdelgd	plunged into ruin, exterminated	è(j)aqètoka		E(y)a'Etoka	E ( y ) a ' E t o k a	ɛ ( j ) a ʔ ɛ t o k a						
-358	484	E	dat niet, bij verbieden	not that, by prohibition	è(j)araq	277	E(y)ara'	E ( y ) a r a '	ɛ ( j ) a r a ʔ						
-359	484	E	handel niet aldus, niet op die wijze	do not act that way, not in that way	è(j)araq noeha	278	E(y)ara' nuha	E ( y ) a r a ' # n u h a	ɛ ( j ) a r a ʔ # n u h a						
-360	484	E	vuur, aangestoken licht	fire, lit light	è(j)obie		E(y)obi	E ( y ) o b i	ɛ ( j ) o b i						
+356	484	E			è(j)aniemaie	38	E(y)animai	E ( y ) a n i m a i	ɛ ( j ) a n i m a i	aniemaie	animai	a n i m a i	51	a n i m a i	
+356	484	E			è(j)aniemaie	38	E(y)animai	E ( y ) a n i m a i	ɛ ( j ) a n i m a i	aniemaie	animai	a n i m a i	684	a n i m a i	
+357	484	E	in het verderf gestort , verdelgd	plunged into ruin , exterminated	è(j)aqètoka		E(y)a'Etoka	E ( y ) a ' E t o k a	ɛ ( j ) a ʔ ɛ t o k a						
+358	484	E	dat niet , bij verbieden	not that , by prohibition	è(j)araq	277	E(y)ara'	E ( y ) a r a '	ɛ ( j ) a r a ʔ						
+359	484	E	handel niet aldus , niet op die wijze	do not act that way , not in that way	è(j)araq_noeha	278	E(y)ara'_nuha	E ( y ) a r a ' _ n u h a	ɛ ( j ) a r a ʔ _ n u h a						
+360	484	E	vuur , aangestoken licht	fire , lit light	è(j)obie		E(y)obi	E ( y ) o b i	ɛ ( j ) o b i						
 361	484	E	beitel	chisel	ĕ(j)opoko		ė(y)opoko	ė ( y ) o p o k o	ə ( j ) o p o k o						
 362	484	E	mond van menschen en dieren	mouths of men and animals	èkaä		Eka'a	E k a ' a	ɛ k a ʔ a						
 363	484	E	eene papajasoort	a species of papaya	èkabaiedoq		Ekabaido'	E k a b a i d o '	ɛ k a b a i d o ʔ						
 364	484	E	baden	bathe	èkabaieka		Ekabaika	E k a b a i k a	ɛ k a b a i k a						
 365	484	E	lijk	corpse	èkabakè		EkabakE	E k a b a k E	ɛ k a b a k ɛ						
-366	484	E	makker, kameraad	companion, comrade	èkabakèka		EkabakEka	E k a b a k E k a	ɛ k a b a k ɛ k a						
+366	484	E	makker , kameraad	companion , comrade	èkabakèka		EkabakEka	E k a b a k E k a	ɛ k a b a k ɛ k a						
 367	484	E	klein werpnet in gebruik bij de zeevischvangst	small casting net used in sea fishing	èkaboeäjo		Ekabu'ayo	E k a b u ' a y o	ɛ k a b u ʔ a j o						
 368	484	E	vleermuis	bat	èkadaboeqä		Ekadabu'a	E k a d a b u ' a	ɛ k a d a b u ʔ a						
 369	484	E	lichaam	body	èkadaha(q)	135	Ekadaha(')	E k a d a h a ( ' )	ɛ k a d a h a ( ʔ )						
 370	484	E	musch	sparrow	èkadieodie	136	Ekadiodi	E k a d i o d i	ɛ k a d i o d i						
 371	484	E	de ontvangkamer van het gezin	the family reception room	èkadieopè	128	EkadiopE	E k a d i o p E	ɛ k a d i o p ɛ						
 372	485	E	zekere boomsoort met deugdzaam timmerhout	certain tree species with decent lumber	èkadodo(q)		Ekadodo(')	E k a d o d o ( ' )	ɛ k a d o d o ( ʔ )						
-373	485	E	doek, geweven stof inz. van katoen, kleedingstuk tot bedekking van het lichaam van den middel tot de voeten	cloth, woven from cotton, article of clothing covering the body from waist to foot	èkaèn		EkaEn	E k a E n	ɛ k a ɛ n						malayː kain
+373	485	E	doek , geweven stof inz. van katoen , kleedingstuk tot bedekking van het lichaam van den middel tot de voeten	cloth , woven from cotton , article of clothing covering the body from waist to foot	èkaèn		EkaEn	E k a E n	ɛ k a ɛ n						malayː kain
 374	485	E	schorpioen	scorpion	èkaha		Ekaha	E k a h a	ɛ k a h a						
 375	485	E	net om vogels te strikken	net to trap birds	èkahaba		Ekahaba	E k a h a b a	ɛ k a h a b a						
 376	485	E	kreeft	lobster	èkahaèpie		EkahaEpi	E k a h a E p i	ɛ k a h a ɛ p i						
 377	485	E	één	one	(è)kahaèq	2	(E)kahaE'	( E ) k a h a E '	( ɛ ) k a h a ɛ ʔ						
 378	485	E	zekere boomsoort met deugdzaam timmerhout	certain tree species with virtuous lumber	èkahanoa		Ekahanoa	E k a h a n o a	ɛ k a h a n o a						
-379	485	E	achterzijde, rug	rear, back	èkahaö		Ekaha'o	E k a h a ' o	ɛ k a h a ʔ o						
+379	485	E	achterzijde , rug	rear , back	èkahaö		Ekaha'o	E k a h a ' o	ɛ k a h a ʔ o						
 380	485	E	buiten eene omheinde plaats	outside a fenced-off area	èkahaoe		Ekahau	E k a h a u	ɛ k a h a u						
 381	485	E	ananas	pineapple	èkahaoekoe		Ekahauku	E k a h a u k u	ɛ k a h a u k u						
 382	485	E	dag	day / hello	èkahaoq		Ekahao'	E k a h a o '	ɛ k a h a o ʔ						
 383	485	E	alang-alang	alang-alang	èkahi(j)oe		Ekahi(y)u	E k a h i ( y ) u	ɛ k a h i ( j ) u						
 384	485	E	witte mier	white ant	èkahieno(a)		Ekahino(a)	E k a h i n o ( a )	ɛ k a h i n o ( a )						
 385	485	E	hagedis	lizard	èkahoe(w)èqo		Ekahu(w)E'o	E k a h u ( w ) E ' o	ɛ k a h u ( w ) ɛ ʔ o						
-386	485	E	drek, uitwerpselen	muck, excrement	èkaie		Ekai	E k a i	ɛ k a i						
-387	485	E	kopje, bordje, schoteltje	cup, plate, saucer	èkaieno(h)		Ekaino(h)	E k a i n o ( h )	ɛ k a i n o ( h )						
-388	485	E	de lucht; ookː wolk, regenwolk	the sky; alsoː cloud, rain cloud	èkaie(oe)dahoe(hoe)	129	Ekai(u)dahu(hu)	E k a i ( u ) d a h u ( h u )	ɛ k a i ( u ) d a h u ( h u )						
+386	485	E	drek , uitwerpselen	muck , excrement	èkaie		Ekai	E k a i	ɛ k a i						
+387	485	E	kopje , bordje , schoteltje	cup , plate , saucer	èkaieno(h)		Ekaino(h)	E k a i n o ( h )	ɛ k a i n o ( h )						
+388	485	E	de lucht ; ookː wolk , regenwolk	the sky ; alsoː cloud , rain cloud	èkaie(oe)dahoe(hoe)	129	Ekai(u)dahu(hu)	E k a i ( u ) d a h u ( h u )	ɛ k a i ( u ) d a h u ( h u )						
 389	485	E	een van de typen van een Engganeesche lans	one of the types of an Engganese lance	èkajoqpèdjie	130	Ekayo'pEji	E k a y o ' p E j i	ɛ k a j o ʔ p ɛ d͡ʒ i						
-390	485	E	weerkaatsing van het licht, schitteren	reflection of light, shine	èkakorèie(j)o	131	EkakorEi(y)o	E k a k o r E i ( y ) o	ɛ k a k o r ɛ i ( j ) o						
+390	485	E	weerkaatsing van het licht , schitteren	reflection of light , shine	èkakorèie(j)o	131	EkakorEi(y)o	E k a k o r E i ( y ) o	ɛ k a k o r ɛ i ( j ) o						
 391	485	E	vijl	file	èkakorè(j)o		EkakorE(y)o	E k a k o r E ( y ) o	ɛ k a k o r ɛ ( j ) o						
 392	485	E	zekere pisangsoort	certain pisang species	èkamie(j)oe		Ekami(y)u	E k a m i ( y ) u	ɛ k a m i ( j ) u						
-393	485	E	op, niet meer voorhanden	finished / spent, no longer available	èkanaja		Ekanaya	E k a n a y a	ɛ k a n a j a						
+393	485	E	op , niet meer voorhanden	finished / spent , no longer available	èkanaja		Ekanaya	E k a n a y a	ɛ k a n a j a						
 394	485	E	kopje	cup	èkanjoq		Ekaño'	E k a ñ o '	ɛ k a ɲ o ʔ						
-395	485	E	damp, wasem	vapour, steam	èkanoa		Ekanoa	E k a n o a	ɛ k a n o a						
+395	485	E	damp , wasem	vapour , steam	èkanoa		Ekanoa	E k a n o a	ɛ k a n o a						
 396	485	E	de maan	the moon	èkanoaie		Ekanoai	E k a n o a i	ɛ k a n o a i						
 397	485	E	vogelklauw	bird's claw	èkanoeoenoe		Ekanu'unu	E k a n u ' u n u	ɛ k a n u ʔ u n u						
 398	485	E	zekere vogel (doendoen)	certain bird (pigeon)	èk(a)oeqpanoe	127	Ek(a)u'panu	E k ( a ) u ' p a n u	ɛ k ( a ) u ʔ p a n u						
-399	485	E	fraai, mooi om te zien	beautiful, nice to see	èkaoe(w)a	134	Ekau(w)a	E k a u ( w ) a	ɛ k a u ( w ) a						gwrd.: aoe(w)a?
-400	485	E	zekere boomsoort, welks hout uitsluitend voor brandhout gebezigd wordt	certain tree species whose wood is used solely for firewood	èkapahoeka		Ekapahuka	E k a p a h u k a	ɛ k a p a h u k a						
+399	485	E	fraai , mooi om te zien	beautiful , nice to see	èkaoe(w)a	134	Ekau(w)a	E k a u ( w ) a	ɛ k a u ( w ) a						gwrd.: aoe(w)a?
+400	485	E	zekere boomsoort , welks hout uitsluitend voor brandhout gebezigd wordt	certain tree species whose wood is used solely for firewood	èkapahoeka		Ekapahuka	E k a p a h u k a	ɛ k a p a h u k a						
 401	485	E	een papegaaisoort	a species of parrot	èkapèlo		EkapElo	E k a p E l o	ɛ k a p ɛ l o						
-402	485	E	oud, in allerlei beteekenissen	old, in all kinds of meanings	èkapoeh		Ekapuh	E k a p u h	ɛ k a p u h						
-403	485	E	mensch, menschdom, lieden	man, humanity, people	èka(q)ka(q)		Eka(')ka(')	E k a ( ' ) k a ( ' )	ɛ k a ( ʔ ) k a ( ʔ )						
-404	485	E	geweven kleeding in het algemeen, stof	woven garments in general, fabric	èkaraoe(w)ahè		Ekarau(w)ahE	E k a r a u ( w ) a h E	ɛ k a r a u ( w ) a h ɛ						
-405	486	E	zweer, puist	ulcer, pustule	èkarèpè	139	EkarEpE	E k a r E p E	ɛ k a r ɛ p ɛ						
-406	486	E	zeer, tot vorming van den overtreffenden trap	very, to formation of the superlative stage	èkarara		Ekarara	E k a r a r a	ɛ k a r a r a						
-407	486	E	oor, oorsieraad, destijds bestaande in opgerolde pisangbladeren, ringen van een kleine soort kokosnoot of van hoorn vervaardigd	ear, ear ornament, then consisting of coiled pisang leaves, rings made of a small type of coconut or of horn	èkarieha	132	Ekariha	E k a r i h a	ɛ k a r i ç a						
-408	486	E	armband (gew. van glaskoralen of akar bahar)	bracelet (usually from glass corals or akar bahar)	èkarieha oe(w)apo	133	Ekariha u(w)apo	E k a r i h a # u ( w ) a p o	ɛ k a r i ç a # u ( w ) a p o						
+402	485	E	oud , in allerlei beteekenissen	old , in all kinds of meanings	èkapoeh		Ekapuh	E k a p u h	ɛ k a p u h						
+403	485	E	mensch , menschdom , lieden	man , humanity , people	èka(q)ka(q)		Eka(')ka(')	E k a ( ' ) k a ( ' )	ɛ k a ( ʔ ) k a ( ʔ )						
+404	485	E	geweven kleeding in het algemeen , stof	woven garments in general , fabric	èkaraoe(w)ahè		Ekarau(w)ahE	E k a r a u ( w ) a h E	ɛ k a r a u ( w ) a h ɛ						
+405	486	E	zweer , puist	ulcer , pustule	èkarèpè	139	EkarEpE	E k a r E p E	ɛ k a r ɛ p ɛ						
+406	486	E	zeer , tot vorming van den overtreffenden trap	very , to formation of the superlative stage	èkarara		Ekarara	E k a r a r a	ɛ k a r a r a						
+407	486	E	oor , oorsieraad , destijds bestaande in opgerolde pisangbladeren , ringen van een kleine soort kokosnoot of van hoorn vervaardigd	ear , ear ornament , then consisting of coiled pisang leaves , rings made of a small type of coconut or of horn	èkarieha	132	Ekariha	E k a r i h a	ɛ k a r i ç a						
+408	486	E	armband (gew. van glaskoralen of akar bahar)	bracelet (usually from glass corals or akar bahar)	èkarieha_oe(w)apo	133	Ekariha_u(w)apo	E k a r i h a _ u ( w ) a p o	ɛ k a r i ç a _ u ( w ) a p o						
 409	486	E	voetring	foot ring	oe(w)aie		u(w)ai	u ( w ) a i	u ( w ) a i						
-410	486	E	citroen, pompelmoes	lemon, grapefruit	èkèè		EkEE	E k E E	ɛ k ɛ ɛ						
+410	486	E	citroen , pompelmoes	lemon , grapefruit	èkèè		EkEE	E k E E	ɛ k ɛ ɛ						
 411	486	E	vogel	bird	èkèèpa	137	EkEEpa	E k E E p a	ɛ k ɛ ɛ p a						
-412	486	E	vliegen, stuiven, opstuiven van stof enz	flying, dusting, kicking up dust etc.	kieèèpa	344	kiEEpa	k i E E p a	k i ɛ ɛ p a						
+412	486	E	vliegen , stuiven , opstuiven van stof enz	flying , dusting , kicking up dust etc.	kieèèpa	344	kiEEpa	k i E E p a	k i ɛ ɛ p a						
 413	486	E	korte breede bijl	short broad axe	èkèh(è)		EkEh(E)	E k E h ( E )	ɛ k ɛ h ( ɛ )						
 414	486	E	doorn	thorn	èkèhèodo		EkEhEodo	E k E h E o d o	ɛ k ɛ h ɛ o d o						
-415	486	E	een instrumentje, dat men tusschen de tanden neemt en daarmede het geluid «ginggong» maakt	a small instrument, which one takes between the teeth and with which one makes the sound “ginggong”	èkèkong		EkEkong	E k E k o n g	ɛ k ɛ k o n g						
+415	486	E	een instrumentje , dat men tusschen de tanden neemt en daarmede het geluid «ginggong» maakt	a small instrument , which one takes between the teeth and with which one makes the sound “ginggong”	èkèkong		EkEkong	E k E k o n g	ɛ k ɛ k o n g						
 416	486	E	milt	spleen	èkèma		EkEma	E k E m a	ɛ k ɛ m a						
 417	486	E	braken	vomit	èkèoäh		EkEo'ah	E k E o ' a h	ɛ k ɛ o ʔ a h						
 418	486	E	rottan	rottan	èkèoq		EkEo'	E k E o '	ɛ k ɛ o ʔ						
 419	486	E	muts	hat	èkèponie		EkEponi	E k E p o n i	ɛ k ɛ p o n i						
 420	486	E	vloeiingen	flows	èkieakie		Ekiaki	E k i a k i	ɛ k i a k i						
-421	486	E	stok met twee of drie ijzeren punten, waarmede de visschen, die uit het net trachten te ontkomen, worden gestoken	stick with two or three iron points, with which the fish trying to escape from the net are stabbed	èkieakoqä		Ekiako'a	E k i a k o ' a	ɛ k i a k o ʔ a						
+421	486	E	stok met twee of drie ijzeren punten , waarmede de visschen , die uit het net trachten te ontkomen , worden gestoken	stick with two or three iron points , with which the fish trying to escape from the net are stabbed	èkieakoqä		Ekiako'a	E k i a k o ' a	ɛ k i a k o ʔ a						
 422	486	E	sprinkhaan	grasshopper	èkieapo	140	Ekiapo	E k i a p o	ɛ k i a p o						
-423	486	E	spaander, splinter	chip, splinter	èkiedapè(j)a	146	EkidapE(y)a	E k i d a p E ( y ) a	ɛ k i d a p ɛ ( j ) a						
+423	486	E	spaander , splinter	chip , splinter	èkiedapè(j)a	146	EkidapE(y)a	E k i d a p E ( y ) a	ɛ k i d a p ɛ ( j ) a						
 424	486	E	een der typen van eene Engganeesche lans	one of the types of an Engganese lance	èkiediebèie(j)oq	147	EkidibEi(y)o'	E k i d i b E i ( y ) o '	ɛ k i d i b ɛ i ( j ) o ʔ						
-425	486	E	buik, ingewanden	abdomen, intestines	èkiedjaie	145	Ekijai	E k i j a i	ɛ k i d͡ʒ a i						
+425	486	E	buik , ingewanden	abdomen , intestines	èkiedjaie	145	Ekijai	E k i j a i	ɛ k i d͡ʒ a i						
 426	486	E	zekere boomsoort met deugdzaam timmerhout	certain tree species with decent lumber	èkiedjè		EkijE	E k i j E	ɛ k i d͡ʒ ɛ	mĕrbau	mėrbau	m ė r b a u	Malay crossref	m ə r b a u	
 427	486	E	Spaansche peper	Spanish pepper	èkiedjiekiedjie		Ekijikiji	E k i j i k i j i	ɛ k i d͡ʒ i k i d͡ʒ i						
 428	486	E	bochtig van een weg	winding road	èkieèèo		EkiEEo	E k i E E o	ɛ k i ɛ ɛ o						
@@ -433,8 +443,8 @@ ID	page	entry	dutch	english	form	variant_ID	form_common_transcription	form_commo
 432	486	E	dorst	thirst	èkiehöa		Ekihu̇a	E k i h u̇ a	ɛ k i ç ɨ a						
 433	486	E	nerf van het kokosblad	vein of the coconut leaf	èkiehoedo		Ekihudo	E k i h u d o	ɛ k i ç u d o						
 434	486	E	eene niet brandende toorts. De toortsen worden van klapperbladeren vervaardigd	a non-burning torch. Torches are made of coconut leaves	èkiehoedo		Ekihudo	E k i h u d o	ɛ k i ç u d o						
-435	486	E	reden, omdat	reason, because	èkiehohè(j)a	138	EkihohE(y)a	E k i h o h E ( y ) a	ɛ k i ç o h ɛ ( j ) a						
-436	486	E	wat is daarvan de reden	what is the reason of that	èieha kiehohè(j)a die(j)a		Eiha kihohE(y)a di(y)a	E i h a # k i h o h E ( y ) a # d i ( y ) a	ɛ i ç a # k i ç o h ɛ ( j ) a # d i ( j ) a						
+435	486	E	reden , omdat	reason , because	èkiehohè(j)a	138	EkihohE(y)a	E k i h o h E ( y ) a	ɛ k i ç o h ɛ ( j ) a						
+436	486	E	wat is daarvan de reden	what is the reason of that	èieha_kiehohè(j)a_die(j)a		Eiha_kihohE(y)a_di(y)a	E i h a _ k i h o h E ( y ) a _ d i ( y ) a	ɛ i ç a _ k i ç o h ɛ ( j ) a _ d i ( j ) a						
 437	486	E	kin	chin	èkieie		Ekii	E k i i	ɛ k i i						
 438	486	E	dauw	dew	èkieie(j)o	142	Ekii(y)o	E k i i ( y ) o	ɛ k i i ( j ) o						
 439	487	E	schild	shield	èkieie(j)ahaq		Ekii(y)aha'	E k i i ( y ) a h a '	ɛ k i i ( j ) a h a ʔ						
@@ -445,68 +455,69 @@ ID	page	entry	dutch	english	form	variant_ID	form_common_transcription	form_commo
 444	487	E	kam	comb	èkiekie		Ekiki	E k i k i	ɛ k i k i						
 445	487	E	eene cassavesoort	a cassava variety	èkiekohaq		Ekikoha'	E k i k o h a '	ɛ k i k o h a ʔ						
 446	487	E	schelp	shell	èkiemo		Ekimo	E k i m o	ɛ k i m o						
-447	487	E	het voor den Engganees onbekende land(?)	The Country Unknown To The Engganese (?)	èkiemo		Ekimo	E k i m o	ɛ k i m o						
-448	487	E	cardamom, langkoewas (een specerijachtige wortel)	cardamom, lenkuas (a spice-like root)	èkienono		Ekinono	E k i n o n o	ɛ k i n o n o						
+447	487	E	het voor den Engganees onbekende land( ? )	The Country Unknown To The Engganese ( ? )	èkiemo		Ekimo	E k i m o	ɛ k i m o						
+448	487	E	cardamom , langkoewas (een specerijachtige wortel)	cardamom , lenkuas (a spice-like root)	èkienono		Ekinono	E k i n o n o	ɛ k i n o n o						
 449	487	E	de hooge kant van iets	the high side of something	èkieodoha		Ekiodoha	E k i o d o h a	ɛ k i o d o h a						
 450	487	E	duizendpoot	centipede	èkietjaho		Ekicaho	E k i c a h o	ɛ k i t͡ʃ a h o						
 451	487	E	haai	shark	èkietjoh		Ekicoh	E k i c o h	ɛ k i t͡ʃ o h						
 452	487	E	hoofddeksel van boomschors	bark headgear	èkietohè		EkitohE	E k i t o h E	ɛ k i t o h ɛ						
-453	487	E	rat, muis	rat, mouse	èkoanoe		Ekoanu	E k o a n u	ɛ k o a n u						
-454	487	E	op zij af, zijweg	off to the side, side road	èköaq		Eku̇a'	E k u̇ a '	ɛ k ɨ a ʔ						
-455	487	E	verhaal, vertelling	story, narration	èkodie(j)o	157	Ekodi(y)o	E k o d i ( y ) o	ɛ k o d i ( j ) o						
-456	487	E	verhaal, vertelsel	story, narration	èkodaäjo	149	Ekoda'ayo	E k o d a ' a y o	ɛ k o d a ʔ a j o						
-457	487	E	stam, boom	trunk, tree	èkoeaka		Ekuaka	E k u a k a	ɛ k u a k a						
+453	487	E	rat , muis	rat , mouse	èkoanoe		Ekoanu	E k o a n u	ɛ k o a n u						
+454	487	E	op zij af , zijweg	off to the side , side road	èköaq		Eku̇a'	E k u̇ a '	ɛ k ɨ a ʔ						
+455	487	E	verhaal , vertelling	story , narration	èkodie(j)o	157	Ekodi(y)o	E k o d i ( y ) o	ɛ k o d i ( j ) o						
+456	487	E	verhaal , vertelsel	story , narration	èkodaäjo	149	Ekoda'ayo	E k o d a ' a y o	ɛ k o d a ʔ a j o						
+457	487	E	stam , boom	trunk , tree	èkoeaka		Ekuaka	E k u a k a	ɛ k u a k a						
 458	487	E	rijk	rich	èkoedodo		Ekudodo	E k u d o d o	ɛ k u d o d o						
-459	487	E	één persoon, lichaam	one person, body	èkoedodoka		Ekudodoka	E k u d o d o k a	ɛ k u d o d o k a						
-460	487	E	stam, boom	trunk, tree	èkoeha	155	Ekuha	E k u h a	ɛ k u h a						
+459	487	E	één persoon , lichaam	one person , body	èkoedodoka		Ekudodoka	E k u d o d o k a	ɛ k u d o d o k a						
+460	487	E	stam , boom	trunk , tree	èkoeha	155	Ekuha	E k u h a	ɛ k u h a						
 461	487	E	raadsel	riddle	èkoehie(j)o		Ekuhi(y)o	E k u h i ( y ) o	ɛ k u h i ( j ) o						
-462	487	E	struik, stengel	bush, stem	èkoeka		Ekuka	E k u k a	ɛ k u k a						
+462	487	E	struik , stengel	bush , stem	èkoeka		Ekuka	E k u k a	ɛ k u k a						
 463	487	E	scheenbeen	shin	èkoeka(oe)waie		Ekuka(u)wai	E k u k a ( u ) w a i	ɛ k u k a ( u ) w a i						
 464	487	E	mug	mosquito	èkoema(q)aoe		Ekuma(')au	E k u m a ( ' ) a u	ɛ k u m a ( ʔ ) a u						
-465	487	E	tak, boomtak	branch, tree branch	èkoena		Ekuna	E k u n a	ɛ k u n a						
+465	487	E	tak , boomtak	branch , tree branch	èkoena		Ekuna	E k u n a	ɛ k u n a						
 466	487	E	baadje	shirt	èkoeöedo		Eku'oedo	E k u ' o e d o	ɛ k u ʔ o e d o						
-467	487	E	omheinen van een bouwland, van een tuin	fencing of an arable land, of a garden	èkoepado	151	Ekupado	E k u p a d o	ɛ k u p a d o						
+467	487	E	omheinen van een bouwland , van een tuin	fencing of an arable land , of a garden	èkoepado	151	Ekupado	E k u p a d o	ɛ k u p a d o						
 468	487	E	een der typen van een Engganeesche lans	one of the types of an Engganese lance	èkoe(w)abo		Eku(w)abo	E k u ( w ) a b o	ɛ k u ( w ) a b o						
 469	487	E	e. s. v. vogel.	a sort of bird	èkoe(w)iekoe(w)ie		Eku(w)iku(w)i	E k u ( w ) i k u ( w ) i	ɛ k u ( w ) i k u ( w ) i						
-470	487	E	tak, boomtak, hout	branch, tree branch, wood	èkoe(w)o	148	Eku(w)o	E k u ( w ) o	ɛ k u ( w ) o						
-471	487	E	zich met bladeren, inz. van den pandanus, beschutten tegen den regen; regenscherm	shelter from the rain with leaves, e.g. of the pandanus; rainscreen	èkohèaq		EkohEa'	E k o h E a '	ɛ k o h ɛ a ʔ						
-472	487	E	heuvel, berg	hill, mountain	èkoh(oie)		Ekoh(oi)	E k o h ( o i )	ɛ k o h ( o i )						
-473	487	E	vuil, handvuil, huidsmeer	dirt, hand dirt, skin grease	èkohoq		Ekoho'	E k o h o '	ɛ k o h o ʔ						
+470	487	E	tak , boomtak , hout	branch , tree branch , wood	èkoe(w)o	148	Eku(w)o	E k u ( w ) o	ɛ k u ( w ) o						
+471	487	E	zich met bladeren , inz. van den pandanus , beschutten tegen den regen ; regenscherm	shelter from the rain with leaves , e.g. of the pandanus ; rainscreen	èkohèaq		EkohEa'	E k o h E a '	ɛ k o h ɛ a ʔ						
+472	487	E	heuvel , berg	hill , mountain	èkoh(oie)		Ekoh(oi)	E k o h ( o i )	ɛ k o h ( o i )						
+473	487	E	vuil , handvuil , huidsmeer	dirt , hand dirt , skin grease	èkohoq		Ekoho'	E k o h o '	ɛ k o h o ʔ						
 474	487	E	asch	ash	èkohoqoe(j)obie		Ekoho'u(y)obi	E k o h o ' u ( y ) o b i	ɛ k o h o ʔ u ( j ) o b i						
-475	487	E	varken, zwijn	pig, boar	èkojoq		Ekoyo'	E k o y o '	ɛ k o j o ʔ						
+475	487	E	varken , zwijn	pig , boar	èkojoq		Ekoyo'	E k o y o '	ɛ k o j o ʔ						
 476	487	E	de borsten van eene vrouw	a woman's breasts	èkokoq		Ekoko'	E k o k o '	ɛ k o k o ʔ						
 477	487	E	clitoris	clitoris	èkonienie		Ekonini	E k o n i n i	ɛ k o n i n i						
 478	487	E	kittelen	tickle	kokonienie		kokonini	k o k o n i n i	k o k o n i n i						
-479	487	E	honger, hongerig zijn	hunger, being hungry	èkonjoq	156	Ekoño'	E k o ñ o '	ɛ k o ɲ o ʔ						
+479	487	E	honger , hongerig zijn	hunger , being hungry	èkonjoq	156	Ekoño'	E k o ñ o '	ɛ k o ɲ o ʔ						
 480	487	E	gevorkte tak	forked branch	èkoq		Eko'	E k o '	ɛ k o ʔ						
-481	488	E	vullen, bevatten, inhouden	fill, contain, contain	èkoqä		Eko'a	E k o ' a	ɛ k o ʔ a						
-482	488	E	overgebleven stam zonder kruin of takken, een tronk	remaining trunk without a crown or branches, a trunk	èkoqa(j)odie(j)a		Eko'a(y)odi(y)a	E k o ' a ( y ) o d i ( y ) a	ɛ k o ʔ a ( j ) o d i ( j ) a						
+481	488	E	vullen , bevatten , inhouden	fill , contain , contain	èkoqä		Eko'a	E k o ' a	ɛ k o ʔ a						
+482	488	E	overgebleven stam zonder kruin of takken , een tronk	remaining trunk without a crown or branches , a trunk	èkoqa(j)odie(j)a		Eko'a(y)odi(y)a	E k o ' a ( y ) o d i ( y ) a	ɛ k o ʔ a ( j ) o d i ( j ) a						
 483	488	E	geneeskundige	medical	èko(q)hajo		Eko(')hayo	E k o ( ' ) h a y o	ɛ k o ( ʔ ) h a j o	doekoen	dukun	d u k u n	Malay crossref	d u k u n	
 484	488	E	nipapalm	nipapalm	èko(ö)qko(ö)q		Eko('o)'ko('o)'	E k o ( ' o ) ' k o ( ' o ) '	ɛ k o ( ʔ o ) ʔ k o ( ʔ o ) ʔ						
 485	488	E	de bagoeboom	the bago tree	èkoq(n)jaoe		Eko'(n)yau	E k o ' ( n ) y a u	ɛ k o ʔ ( n ) j a u						
 486	488	E	voorhoofd	forehead	èkoqoeie		Eko'ui	E k o ' u i	ɛ k o ʔ u i						
-487	488	E	hersenen, merg	brain, marrow	èkoropie	158	Ekoropi	E k o r o p i	ɛ k o r o p i						also èkoropie(j)oèoeloe
-488	488	E	pad, gang.	path, corridor.	èko(w)a		Eko(w)a	E k o ( w ) a	ɛ k o ( w ) a						
-489	488	E	geest, zoowel goede als kwade	spirit, both good and evil	èko(w)èq	152	Eko(w)E'	E k o ( w ) E '	ɛ k o ( w ) ɛ ʔ						
-490	488	E	geest, die de bronnen bewoont	spirit inhabiting the springs	èko(w)èq	153	Eko(w)E'	E k o ( w ) E '	ɛ k o ( w ) ɛ ʔ						oeèbo?
-491	488	E	geest, die de zee bewoont	spirit inhabiting the sea	èoe(w)è		Eu(w)E	E u ( w ) E	ɛ u ( w ) ɛ						
-492	488	E	geest, die de rivieren bewoont	spirit inhabiting the rivers	ie(j)akapieta	276	i(y)akapita	i ( y ) a k a p i t a	i ( j ) a k a p i t a						
-493	488	E	geest, die de doesoen bewoont	spirit inhabiting the doesoen (village)	kaoedara		kaudara	k a u d a r a	k a u d a r a						
-494	488	E	geest, die de bosschen bewoont	spirit, inhabiting the forests	oehoeqkoe(w)o	435	uhu'ku(w)o	u h u ' k u ( w ) o	u h u ʔ k u ( w ) o						
-495	488	E	geest, die de zeekust bewoont	spirit, inhabiting the seashore	oewokie		uwoki	u w o k i	u w o k i						
-496	488	E	naam aan een inlander — vreemdeling — inz. aan een Maleier toegekend	name given to a native - foreigner - e.g., to a Malaysian	èko(w)èq	154	Eko(w)E'	E k o ( w ) E '	ɛ k o ( w ) ɛ ʔ						
+487	488	E	hersenen , merg	brain , marrow	èkoropie	158	Ekoropi	E k o r o p i	ɛ k o r o p i						also èkoropie(j)oèoeloe
+488	488	E	pad , gang.	path , corridor.	èko(w)a		Eko(w)a	E k o ( w ) a	ɛ k o ( w ) a						
+489	488	E	geest , zoowel goede als kwade	spirit , both good and evil	èko(w)èq	152	Eko(w)E'	E k o ( w ) E '	ɛ k o ( w ) ɛ ʔ						
+490	488	E	geest , die de bronnen bewoont	spirit inhabiting the springs	èko(w)èq	153	Eko(w)E'	E k o ( w ) E '	ɛ k o ( w ) ɛ ʔ						oeèbo?
+491	488	E	geest , die de zee bewoont	spirit inhabiting the sea	èoe(w)è		Eu(w)E	E u ( w ) E	ɛ u ( w ) ɛ						
+492	488	E	geest , die de rivieren bewoont	spirit inhabiting the rivers	ie(j)akapieta	276	i(y)akapita	i ( y ) a k a p i t a	i ( j ) a k a p i t a						
+493	488	E	geest , die de doesoen bewoont	spirit inhabiting the doesoen (village)	kaoedara		kaudara	k a u d a r a	k a u d a r a						
+494	488	E	geest , die de bosschen bewoont	spirit , inhabiting the forests	oehoeqkoe(w)o	435	uhu'ku(w)o	u h u ' k u ( w ) o	u h u ʔ k u ( w ) o						
+495	488	E	geest , die de zeekust bewoont	spirit , inhabiting the seashore	oewokie		uwoki	u w o k i	u w o k i						
+496	488	E	naam aan een inlander — vreemdeling — inz. aan een Maleier toegekend	name given to a native - foreigner - e.g. , to a Malaysian	èko(w)èq	154	Eko(w)E'	E k o ( w ) E '	ɛ k o ( w ) ɛ ʔ						
 497	488	E	krokodil	crocodile	èlaäpoe(w)a	159	Ela'apu(w)a	E l a ' a p u ( w ) a	ɛ l a ʔ a p u ( w ) a						
-498	488	E	nicht	niece / cousin	èlahaö	162	Elaha'o	E l a h a ' o	ɛ l a h a ʔ o	èhöda	Ehu̇da	E h u̇ d a	322 ; 834	ɛ h ɨ d a	
+498	488	E	nicht	niece / cousin	èlahaö	162	Elaha'o	E l a h a ' o	ɛ l a h a ʔ o	èhöda	Ehu̇da	E h u̇ d a	322	ɛ h ɨ d a	
+498	488	E	nicht	niece / cousin	èlahaö	162	Elaha'o	E l a h a ' o	ɛ l a h a ʔ o	èhöda	Ehu̇da	E h u̇ d a	834	ɛ h ɨ d a	
 499	488	E	neef	nephew / cousin	èmanie	173	Emani	E m a n i	ɛ m a n i						
 500	488	E	donder	thunder	èlaohoe		Elaohu	E l a o h u	ɛ l a o h u						
-501	488	E	klimmen zooals bijv. in een kokospalm	climbing as, for example, in a coconut tree	èlè		ElE	E l E	ɛ l ɛ						
+501	488	E	klimmen zooals bijv. in een kokospalm	climbing as , for example , in a coconut tree	èlè		ElE	E l E	ɛ l ɛ						
 502	488	E	snot	snot	èlèaq		ElEa'	E l E a '	ɛ l ɛ a ʔ						
-503	488	E	weerlicht, bliksem	lightning	èloaba		Eloaba	E l o a b a	ɛ l o a b a						
-504	488	E	boot (sampan), vaartuig	boat (sampan), vessel	èloha	169	Eloha	E l o h a	ɛ l o h a						
+503	488	E	weerlicht , bliksem	lightning	èloaba		Eloaba	E l o a b a	ɛ l o a b a						
+504	488	E	boot (sampan) , vaartuig	boat (sampan) , vessel	èloha	169	Eloha	E l o h a	ɛ l o h a						
 505	488	E	e. s. v. vogel.	a sort of bird	èmahokakie		Emahokaki	E m a h o k a k i	ɛ m a h o k a k i						
 506	488	E	mannelijk	male	èmanie	174	Emani	E m a n i	ɛ m a n i						
 507	488	E	planken vloer	wooden floor	èmènahoa	176	EmEnahoa	E m E n a h o a	ɛ m ɛ n a h o a						
-508	488	E	vocht uit de kokosnoot, palmwijn	liquid from the coconut, palm wine	èmèno		EmEno	E m E n o	ɛ m ɛ n o						
+508	488	E	vocht uit de kokosnoot , palmwijn	liquid from the coconut , palm wine	èmèno		EmEno	E m E n o	ɛ m ɛ n o						
 509	488	E	kat	cat	èmèo	175	EmEo	E m E o	ɛ m ɛ o						
 510	488	E	de arenpalm	the spike palm	èmienoemienoe		Eminuminu	E m i n u m i n u	ɛ m i n u m i n u						
 511	488	E	zekere boomsoort met deugdzaam timmerhout	certain tree species with decent lumber	èmoamoq		Emoamo'	E m o a m o '	ɛ m o a m o ʔ						
@@ -514,156 +525,162 @@ ID	page	entry	dutch	english	form	variant_ID	form_common_transcription	form_commo
 513	488	E	zekere boomsoort met deugdzaam timmerhout	certain tree species with decent lumber	èmomoq		Emomo'	E m o m o '	ɛ m o m o ʔ						
 514	488	E	wrong	wrong	èmoöie(j)a	177	Emo'oi(y)a	E m o ' o i ( y ) a	ɛ m o ʔ o i ( j ) a						
 515	488	E	moeder van menschen en dieren	mother of humans and animals	ènaè(na)		EnaE(na)	E n a E ( n a )	ɛ n a ɛ ( n a )						
-516	488	E	duim	thumb	ènaè(na): oe(w)apo	178	EnaE(na): u(w)apo	E n a E ( n a ) : # u ( w ) a p o	ɛ n a ɛ ( n a ) : # u ( w ) a p o						
+516	488	E	duim	thumb	ènaè(na):_oe(w)apo	178	EnaE(na):_u(w)apo	E n a E ( n a ) : _ u ( w ) a p o	ɛ n a ɛ ( n a ) : _ u ( w ) a p o						
 517	488	E	groote toon	great tone	oe(w)aie		u(w)ai	u ( w ) a i	u ( w ) a i						
 518	488	E	uitleggers van een boot (sampan)	floats of a boat (sampan)	ènana		Enana	E n a n a	ɛ n a n a						
-519	488	E	baar, golf, deining	bar, wave, swell	ènanaoe(w)è		Enanau(w)E	E n a n a u ( w ) E	ɛ n a n a u ( w ) ɛ						
+519	488	E	baar , golf , deining	bar , wave , swell	ènanaoe(w)è		Enanau(w)E	E n a n a u ( w ) E	ɛ n a n a u ( w ) ɛ						
 520	488	E	vlak terrein	flat terrain	ènapa	181	Enapa	E n a p a	ɛ n a p a						
 521	489	E	moesang	musang / palm civet	ènapienapie	179	Enapinapi	E n a p i n a p i	ɛ n a p i n a p i						
-522	489	E	nauw, benepen, bekneld, geklemd	narrow, pinched, wedged	ènapienie	180	Enapini	E n a p i n i	ɛ n a p i n i						
-523	489	E	met de beenen wijd uit elkander bij het loopen, als kinderen	with legs wide apart when walking, like children	ènè		EnE	E n E	ɛ n ɛ						
+522	489	E	nauw , benepen , bekneld , geklemd	narrow , pinched , wedged	ènapienie	180	Enapini	E n a p i n i	ɛ n a p i n i						
+523	489	E	met de beenen wijd uit elkander bij het loopen , als kinderen	with legs wide apart when walking , like children	ènè		EnE	E n E	ɛ n ɛ						
 524	489	E	zekere boomsoort met deugdzaam timmerhout	certain tree species with decent lumber	ènèhèie		EnEhEi	E n E h E i	ɛ n ɛ h ɛ i						
 525	489	E	lokaas	bait	ènèanèa		EnEanEa	E n E a n E a	ɛ n ɛ a n ɛ a						
 526	489	E	hoofddoek	headscarf	ènèka		EnEka	E n E k a	ɛ n ɛ k a						
-527	489	E	snauwen, afsnauwen	snarl, snap at	ènieènie(j)a		EniEni(y)a	E n i E n i ( y ) a	ɛ n i ɛ n i ( j ) a						
+527	489	E	snauwen , afsnauwen	snarl , snap at	ènieènie(j)a		EniEni(y)a	E n i E n i ( y ) a	ɛ n i ɛ n i ( j ) a						
 528	489	E	naam	name	ènie(j)o		Eni(y)o	E n i ( y ) o	ɛ n i ( j ) o						
 529	489	E	tand	tooth	ènienie		Enini	E n i n i	ɛ n i n i						
-530	489	E	zwaar, drukkend	heavy, oppressive	ènoä	182	Eno'a	E n o ' a	ɛ n o ʔ a						
-531	489	E	diep, diepte	deep, depth	ènoeqoeq		Enu'u'	E n u ' u '	ɛ n u ʔ u ʔ						
+530	489	E	zwaar , drukkend	heavy , oppressive	ènoä	182	Eno'a	E n o ' a	ɛ n o ʔ a						
+531	489	E	diep , diepte	deep , depth	ènoeqoeq		Enu'u'	E n u ' u '	ɛ n u ʔ u ʔ						
 532	489	E	droog van het jaargetijde	dry of the season	ènohaie		Enohai	E n o h a i	ɛ n o h a i						
 533	489	E	de middel	the waist	ènomonomo		Enomonomo	E n o m o n o m o	ɛ n o m o n o m o						
 534	489	E	mansvracht	man-freight	ènoöhoq		Eno'oho'	E n o ' o h o '	ɛ n o ʔ o h o ʔ						
-535	489	E	damp, wasem	vapour, steam	èoaba		Eoaba	E o a b a	ɛ o a b a						
-536	489	E	varken, zwijn	pig, boar	èobo		Eobo	E o b o	ɛ o b o						
-537	489	E	waarde, prijs	value, price	èodie	205	Eodi	E o d i	ɛ o d i						
-538	489	E	hoeveel kost het?	how much does it cost?	apieha èodiedie(j)a	42	apiha Eodidi(y)a	a p i h a # E o d i d i ( y ) a	a p i ç a # ɛ o d i d i ( j ) a						
+535	489	E	damp , wasem	vapour , steam	èoaba		Eoaba	E o a b a	ɛ o a b a						
+536	489	E	varken , zwijn	pig , boar	èobo		Eobo	E o b o	ɛ o b o						
+537	489	E	waarde , prijs	value , price	èodie	205	Eodi	E o d i	ɛ o d i						
+538	489	E	hoeveel kost het ? 	how much does it cost ? 	apieha_èodiedie(j)a	42	apiha_Eodidi(y)a	a p i h a _ E o d i d i ( y ) a	a p i ç a _ ɛ o d i d i ( j ) a						
 539	489	E	verkoopen	sell	èodieaäq	206	Eodia'a'	E o d i a ' a '	ɛ o d i a ʔ a ʔ						
 540	489	E	zich bezig houden met verkoopen	engage in sales	bodieaäq	57	bodia'a'	b o d i a ' a '	b o d i a ʔ a ʔ						
 541	489	E	handel drijven	trade	kahohodieaäq	315	kahohodia'a'	k a h o h o d i a ' a '	k a h o h o d i a ʔ a ʔ						
-542	489	E	schuld, geldschuld	debt, monetary debt	èodieöka	207	Eodi'oka	E o d i ' o k a	ɛ o d i ʔ o k a						
+542	489	E	schuld , geldschuld	debt , monetary debt	èodieöka	207	Eodi'oka	E o d i ' o k a	ɛ o d i ʔ o k a						
 543	489	E	roeiriem	oar	èodjie		Eoji	E o j i	ɛ o d͡ʒ i						
-544	489	E	scherp, scherpsnijdend	sharp, cutting	èodo		Eodo	E o d o	ɛ o d o						
+544	489	E	scherp , scherpsnijdend	sharp , cutting	èodo		Eodo	E o d o	ɛ o d o						
 545	489	E	verplaatsen van eene nederzetting	moving a settlement	èodöda		Eodu̇da	E o d u̇ d a	ɛ o d ɨ d a						
 546	489	E	de mĕngkoedoe	the madder	èodoe	208	Eodu	E o d u	ɛ o d u						
 547	489	E	de balken die dienen om daarop zolder of vloer te leggen	the beams that serve to lay loft or floor thereon	èodohèie	209	EodohEi	E o d o h E i	ɛ o d o h ɛ i						
-548	489	E	huis, woning	house, dwelling	èoeba	188	Euba	E u b a	ɛ u b a						
-549	489	E	kist, koffer	chest, case	èoeba: èkaèn	189	Euba: EkaEn	E u b a : # E k a E n	ɛ u b a : # ɛ k a ɛ n						
+548	489	E	huis , woning	house , dwelling	èoeba	188	Euba	E u b a	ɛ u b a						
+549	489	E	kist , koffer	chest , case	èoeba:_èkaèn	189	Euba:_EkaEn	E u b a : _ E k a E n	ɛ u b a : _ ɛ k a ɛ n						
 550	489	E	kippenhok	chicken coop	èkieadoboe	141	Ekiadobu	E k i a d o b u	ɛ k i a d o b u						
 551	489	E	varkenshok	pig pen	èkojoq	185	Ekoyo'	E k o y o '	ɛ k o j o ʔ						
-552	489	E	woning van dikke, dicht aaneensluitende, loodrecht in den grond geplante stammen inz. van den niboeng	house of thick, close together, perpendicularly planted trunks e.g. of the nibung	ètèbè		EtEbE	E t E b E	ɛ t ɛ b ɛ						
-553	489	E	nest, vogelkooi	nest, birdcage	kèèèpa	334	kEEEpa	k E E E p a	k ɛ ɛ ɛ p a						
-554	489	E	levend, frisch, versch	alive, fresh, fresh	èoeda		Euda	E u d a	ɛ u d a						
+552	489	E	woning van dikke , dicht aaneensluitende , loodrecht in den grond geplante stammen inz. van den niboeng	house of thick , close together , perpendicularly planted trunks e.g. of the nibung	ètèbè		EtEbE	E t E b E	ɛ t ɛ b ɛ						
+553	489	E	nest , vogelkooi	nest , birdcage	kèèèpa	334	kEEEpa	k E E E p a	k ɛ ɛ ɛ p a						
+554	489	E	levend , frisch , versch	alive , fresh , fresh	èoeda		Euda	E u d a	ɛ u d a						
 555	489	E	bast	bark	èoedie		Eudi	E u d i	ɛ u d i						
 556	489	E	hoofd in alle beteekenissen	head in all senses	èoedoe	195	Eudu	E u d u	ɛ u d u						
-557	489	E	oorsprong eener rivier	origin of a river	èoedoe bèlo(w)a	196	Eudu bElo(w)a	E u d u # b E l o ( w ) a	ɛ u d u # b ɛ l o ( w ) a						
+557	489	E	oorsprong eener rivier	origin of a river	èoedoe_bèlo(w)a	196	Eudu_bElo(w)a	E u d u _ b E l o ( w ) a	ɛ u d u _ b ɛ l o ( w ) a						
 558	489	E	mat van de pandanus vervaardigd	mat made from the pandanus	èoeèhè(j)a		EuEhE(y)a	E u E h E ( y ) a	ɛ u ɛ h ɛ ( j ) a						
 559	489	E	uil (vogel)	owl (bird)	èoehoe		Euhu	E u h u	ɛ u h u						
 560	489	E	geldboete	fine	èoeko		Euko	E u k o	ɛ u k o						
 561	489	E	veest	fart	èoekoe		Euku	E u k u	ɛ u k u						
-562	490	E	lange stok, duwboom op vaartuigen	long stick, push bar on vessels	èoekoeaie		Eukuai	E u k u a i	ɛ u k u a i						
+562	490	E	lange stok , duwboom op vaartuigen	long stick , push bar on vessels	èoekoeaie		Eukuai	E u k u a i	ɛ u k u a i						
 563	490	E	de lippen	the lips	èoekoediepo	192	Eukudipo	E u k u d i p o	ɛ u k u d i p o						
 564	490	E	naald	needle	èoekoeie		Eukui	E u k u i	ɛ u k u i						
 565	490	E	vertikale omwandingsplanken	vertical wall planks	èoekoeqoe		Euku'u	E u k u ' u	ɛ u k u ʔ u						
-566	490	E	voorhoofdsband, bestaande uit een boomblad nu en dan versierd met de vederen van een papegaaisoort	forehead band consisting of a tree leaf occasionally decorated with the feathers of a parrot species	èoekoe(w)aie		Euku(w)ai	E u k u ( w ) a i	ɛ u k u ( w ) a i						
+566	490	E	voorhoofdsband , bestaande uit een boomblad nu en dan versierd met de vederen van een papegaaisoort	forehead band consisting of a tree leaf occasionally decorated with the feathers of a parrot species	èoekoe(w)aie		Euku(w)ai	E u k u ( w ) a i	ɛ u k u ( w ) a i						
 567	490	E	eene groene wilde duif	a green wild pigeon	èoema		Euma	E u m a	ɛ u m a						
 568	490	E	een in het wild groeiende notenmuscaatboom	a nutmeg tree growing in the wild	èoemiehie		Eumihi	E u m i h i	ɛ u m i ç i						
-569	490	E	vlieg	fly	èoemo	197	Eumo	E u m o	ɛ u m o	èbaka	Ebaka	E b a k a	214 ; 215 ; 234	ɛ b a k a	
+569	490	E	vlieg	fly	èoemo	197	Eumo	E u m o	ɛ u m o	èbaka	Ebaka	E b a k a	214	ɛ b a k a	
+569	490	E	vlieg	fly	èoemo	197	Eumo	E u m o	ɛ u m o	èbaka	Ebaka	E b a k a	215	ɛ b a k a	
+569	490	E	vlieg	fly	èoemo	197	Eumo	E u m o	ɛ u m o	èbaka	Ebaka	E b a k a	234	ɛ b a k a	
 570	490	E	mand van gevlochten rottan	basket of woven rottan	èoenèkè		EunEkE	E u n E k E	ɛ u n ɛ k ɛ						
 571	490	E	zeegarnaal	prawn	è(oe)noekie(j)o		E(u)nuki(y)o	E ( u ) n u k i ( y ) o	ɛ ( u ) n u k i ( j ) o						
-572	490	E	steel om iets mee aan te vatten, steel van bloemen, vruchten enz.	stem to hold on to something, stem of a flower, fruits, etc.	èoeoe		Eu'u	E u ' u	ɛ u ʔ u						
+572	490	E	steel om iets mee aan te vatten , steel van bloemen , vruchten enz.	stem to hold on to something , stem of a flower , fruits , etc.	èoeoe		Eu'u	E u ' u	ɛ u ʔ u						
 573	490	E	benedenarm	forearm	èoeoe(w)apo	198	Eu'u(w)apo	E u ' u ( w ) a p o	ɛ u ʔ u ( w ) a p o						
 574	490	E	landschildpad	land tortoise	èoeoenoe		Eu'unu	E u ' u n u	ɛ u ʔ u n u						
 575	490	E	de betelnootpalm	the betel nut palm	èoepo	190	Eupo	E u p o	ɛ u p o						
-576	490	E	bloem, bloesem	flower, blossom	èoepoeie(j)o	199	Eupui(y)o	E u p u i ( y ) o	ɛ u p u i ( j ) o						
-577	490	E	huiduitslag, muggebeet	skin rash, mosquito bite	èoepoeqoe(w)o	200	Eupu'u(w)o	E u p u ' u ( w ) o	ɛ u p u ʔ u ( w ) o						
-578	490	E	hard loopen, hard wegloopen	run fast, run away fast	èoepoe(w)a	191	Eupu(w)a	E u p u ( w ) a	ɛ u p u ( w ) a						
+576	490	E	bloem , bloesem	flower , blossom	èoepoeie(j)o	199	Eupui(y)o	E u p u i ( y ) o	ɛ u p u i ( j ) o						
+577	490	E	huiduitslag , muggebeet	skin rash , mosquito bite	èoepoeqoe(w)o	200	Eupu'u(w)o	E u p u ' u ( w ) o	ɛ u p u ʔ u ( w ) o						
+578	490	E	hard loopen , hard wegloopen	run fast , run away fast	èoepoe(w)a	191	Eupu(w)a	E u p u ( w ) a	ɛ u p u ( w ) a						
 579	490	E	een rottansoort	a rottan species	èoe(w)a		Eu(w)a	E u ( w ) a	ɛ u ( w ) a						
 580	490	E	voet	foot	èoe(w)aie	186	Eu(w)ai	E u ( w ) a i	ɛ u ( w ) a i						
-581	490	E	uitspreken van een woord, van een naam	pronouncing a word, a name	èoe(w)aka		Eu(w)aka	E u ( w ) a k a	ɛ u ( w ) a k a						
+581	490	E	uitspreken van een woord , van een naam	pronouncing a word , a name	èoe(w)aka		Eu(w)aka	E u ( w ) a k a	ɛ u ( w ) a k a						
 582	490	E	bovenarm	upper arm	èoe(w)apo	187	Eu(w)apo	E u ( w ) a p o	ɛ u ( w ) a p o						
-583	490	E	slapen, dutten	sleeping, napping	èoe(w)oho		Eu(w)oho	E u ( w ) o h o	ɛ u ( w ) o h o						
-584	490	E	fluiten van vogels	birdsong	è(o)hora; è(o)horaoekèèpa	63	E(o)hora; E(o)horaukEEpa	E ( o ) h o r a ; # E ( o ) h o r a u k E E p a	ɛ ( o ) h o r a ; # ɛ ( o ) h o r a u k ɛ ɛ p a						
+583	490	E	slapen , dutten	sleeping , napping	èoe(w)oho		Eu(w)oho	E u ( w ) o h o	ɛ u ( w ) o h o						
+584	490	E	fluiten van vogels	birdsong	è(o)hora	63	E(o)hora	E ( o ) h o r a	ɛ ( o ) h o r a						
+584	490	E	fluiten van vogels	birdsong	è(o)horaoekèèpa	63	E(o)horaukEEpa	E ( o ) h o r a u k E E p a	ɛ ( o ) h o r a u k ɛ ɛ p a						
 585	490	E	achterhoofd	occiput	èokaha		Eokaha	E o k a h a	ɛ o k a h a						
 586	490	E	nek	neck	èokahao	202	Eokahao	E o k a h a o	ɛ o k a h a o						
 587	490	E	lachen	laugh	èokaq		Eoka'	E o k a '	ɛ o k a ʔ						
 588	490	E	eene manggasoort	a mango species	èokie(j)o		Eoki(y)o	E o k i ( y ) o	ɛ o k i ( j ) o						
-589	490	E	wig, keg.	wedge, wedge.	èoko		Eoko	E o k o	ɛ o k o						
+589	490	E	wig , keg.	wedge , wedge.	èoko		Eoko	E o k o	ɛ o k o						
 590	490	E	droogplaats voor klappers en visch.	drying place for clappers and fish.	èokoa		Eokoa	E o k o a	ɛ o k o a						
-591	490	E	model, proef, maat	model, trial, size	èoko(ĕ)		Eoko(ė)	E o k o ( ė )	ɛ o k o ( ə )						
-592	490	E	hoofdkussen	pillow	èokoeh; èokoehèoedoe	203	Eokuh; EokuhEudu	E o k u h ; # E o k u h E u d u	ɛ o k u h ; # ɛ o k u h ɛ u d u						
-593	490	E	glad, effen, schaaf	smooth, even, plane	èokohè		EokohE	E o k o h E	ɛ o k o h ɛ						
+591	490	E	model , proef , maat	model , trial , size	èoko(ĕ)		Eoko(ė)	E o k o ( ė )	ɛ o k o ( ə )						
+592	490	E	hoofdkussen	pillow	èokoeh	203	Eokuh	E o k u h	ɛ o k u h						
+592	490	E	hoofdkussen	pillow	èokoehèoedoe	203	EokuhEudu	E o k u h E u d u	ɛ o k u h ɛ u d u						
+593	490	E	glad , effen , schaaf	smooth , even , plane	èokohè		EokohE	E o k o h E	ɛ o k o h ɛ						
 594	490	E	het over iets smals heengaan	passing over something narrow	èokomè		EokomE	E o k o m E	ɛ o k o m ɛ						
 595	490	E	dekkleed van boomschors	blanket made of bark	èokopie	204	Eokopi	E o k o p i	ɛ o k o p i						
 596	490	E	touw	rope	èokoq		Eoko'	E o k o '	ɛ o k o ʔ						
-597	490	E	bewaken, waken, wakker zijn, de wacht houden, wachten, toeven	guarding, watching, being awake, keeping watch, waiting, dwelling	èomo(kie)		Eomo(ki)	E o m o ( k i )	ɛ o m o ( k i )						
-598	490	E	iets verplaatsen, verzetten	move something, displace	èomohoĕ		Eomohoė	E o m o h o ė	ɛ o m o h o ə						
-599	490	E	hoeveelheid, aantal	quantity, number	èomona		Eomona	E o m o n a	ɛ o m o n a						
+597	490	E	bewaken , waken , wakker zijn , de wacht houden , wachten , toeven	guarding , watching , being awake , keeping watch , waiting , dwelling	èomo(kie)		Eomo(ki)	E o m o ( k i )	ɛ o m o ( k i )						
+598	490	E	iets verplaatsen , verzetten	move something , displace	èomohoĕ		Eomohoė	E o m o h o ė	ɛ o m o h o ə						
+599	490	E	hoeveelheid , aantal	quantity , number	èomona		Eomona	E o m o n a	ɛ o m o n a						
 600	491	E	zweet	sweat	èomoqö		Eomo'u̇	E o m o ' u̇	ɛ o m o ʔ ɨ						
 601	491	E	e. s. v. beitel	a sort of chisel	èonokĕ		Eonokė	E o n o k ė	ɛ o n o k ə						
 602	491	E	een rottansoort	a rottan species	èononie		Eononi	E o n o n i	ɛ o n o n i						
-603	491	E	stok, staak	stick, stake	èoöbaq		Eo'oba'	E o ' o b a '	ɛ o ʔ o b a ʔ						
+603	491	E	stok , staak	stick , stake	èoöbaq		Eo'oba'	E o ' o b a '	ɛ o ʔ o b a ʔ						
 604	491	E	ravijn	ravine	èoöbo		Eo'obo	E o ' o b o	ɛ o ʔ o b o						
 605	491	E	kruipen zooals kleine kinderen	crawling like little children	èoöboq		Eo'obo'	E o ' o b o '	ɛ o ʔ o b o ʔ						
 606	491	E	zaag	saw	èoökie		Eo'oki	E o ' o k i	ɛ o ʔ o k i						
 607	491	E	kalebas	gourd	èopa		Eopa	E o p a	ɛ o p a						
 608	491	E	een grassoort	a species of grass	èopoe	201	Eopu	E o p u	ɛ o p u						
 609	491	E	keel	throat	èoqoe		Eo'u	E o ' u	ɛ o ʔ u						
-610	491	E	hard, sterk, krachtig	hard, strong, powerful	èoqoq		Eo'o'	E o ' o '	ɛ o ʔ o ʔ						
+610	491	E	hard , sterk , krachtig	hard , strong , powerful	èoqoq		Eo'o'	E o ' o '	ɛ o ʔ o ʔ						
 611	491	E	luidkeels lachen	loudly laughing	èoqoqie		Eo'o'i	E o ' o ' i	ɛ o ʔ o ʔ i						
 612	491	E	rottanmand	rottan basket	èoraie		Eorai	E o r a i	ɛ o r a i						
 613	491	E	kies	select / molar tooth	èpa		Epa	E p a	ɛ p a						
-614	491	E	huwen, huwelijk	marry, marriage	èpa(ä)hona		Epa('a)hona	E p a ( ' a ) h o n a	ɛ p a ( ʔ a ) h o n a	hona(o)	hona(o)	h o n a ( o )	737	h o n a ( o )	
-615	491	E	vriend, bevriend zijn met	friend, being a friend of	èpaäno		Epa'ano	E p a ' a n o	ɛ p a ʔ a n o						
-616	491	E	vast, gedegen	solid, thorough	èpaäo		Epa'ao	E p a ' a o	ɛ p a ʔ a o						
-617	491	E	oorlog, gevecht	war, battle	èpaboriekie		Epaboriki	E p a b o r i k i	ɛ p a b o r i k i						
+614	491	E	huwen , huwelijk	marry , marriage	èpa(ä)hona		Epa('a)hona	E p a ( ' a ) h o n a	ɛ p a ( ʔ a ) h o n a	hona(o)	hona(o)	h o n a ( o )	737	h o n a ( o )	
+615	491	E	vriend , bevriend zijn met	friend , being a friend of	èpaäno		Epa'ano	E p a ' a n o	ɛ p a ʔ a n o						
+616	491	E	vast , gedegen	solid , thorough	èpaäo		Epa'ao	E p a ' a o	ɛ p a ʔ a o						
+617	491	E	oorlog , gevecht	war , battle	èpaboriekie		Epaboriki	E p a b o r i k i	ɛ p a b o r i k i						
 618	491	E	met zijn velen tegelijk	many at a time	èpadoedoe		Epadudu	E p a d u d u	ɛ p a d u d u						
 619	491	E	riviergarnaal	river shrimp	èpaèka		EpaEka	E p a E k a	ɛ p a ɛ k a						
 620	491	E	beweenen van een afgestorven bloedverwant	grieving of a dead relative	èpaèloèpaèloie		EpaElupaEloi	E p a E l u p a E l o i	ɛ p a ɛ l u p a ɛ l o i						
 621	491	E	koevoet van hout	wooden crowbar	èpaènoqjaqä		EpaEno'ya'a	E p a E n o ' y a ' a	ɛ p a ɛ n o ʔ j a ʔ a						
-622	491	E	vleugel, vlerk	wing, wing	èpaèpa	98	EpaEpa	E p a E p a	ɛ p a ɛ p a						
-623	491	E	schelden, uitschelden	swearing, cuss out	èpahiedoa		Epahidoa	E p a h i d o a	ɛ p a h i d o a						
-624	491	E	een ovalen bak, waarin de vruchten van de bagoe, na geschild te zijn, kaladie of onrijpe pisang met een stamper van steen worden fijngestampt	an oval container, in which the fruits of bagu, after being peeled, kaladie or unripe pisang are mashed with a pestle made of stone	èpahjoe		Epahyu	E p a h y u	ɛ p a h j u						
+622	491	E	vleugel , vlerk	wing , wing	èpaèpa	98	EpaEpa	E p a E p a	ɛ p a ɛ p a						
+623	491	E	schelden , uitschelden	swearing , cuss out	èpahiedoa		Epahidoa	E p a h i d o a	ɛ p a h i d o a						
+624	491	E	een ovalen bak , waarin de vruchten van de bagoe , na geschild te zijn , kaladie of onrijpe pisang met een stamper van steen worden fijngestampt	an oval container , in which the fruits of bagu , after being peeled , kaladie or unripe pisang are mashed with a pestle made of stone	èpahjoe		Epahyu	E p a h y u	ɛ p a h j u						
 625	491	E	een stamper van steen	a stone pestle	èèdako	94	EEdako	E E d a k o	ɛ ɛ d a k o						
-626	491	E	breed, breedte	wide, width	èpaho		Epaho	E p a h o	ɛ p a h o						
-627	491	E	verboden zaak, zich onthouden van iets, verboden als schadelijk, als onbetamelijk, verboden en ongeoorloofd bij een sterfgeval	forbidden thing, abstain from something, forbidden as harmful, as unbecoming, forbidden and unauthorised in case of death	èpahoäq	210	Epaho'a'	E p a h o ' a '	ɛ p a h o ʔ a ʔ						
-628	491	E	toornig, vertoornd, boos, vergramd	wrathful, wroth, angry, enraged	èpahoe(w)a		Epahu(w)a	E p a h u ( w ) a	ɛ p a h u ( w ) a						
-629	491	E	bedrog, list, streek	deception, trickery, prank	èpaienoä		Epaino'a	E p a i n o ' a	ɛ p a i n o ʔ a						
+626	491	E	breed , breedte	wide , width	èpaho		Epaho	E p a h o	ɛ p a h o						
+627	491	E	verboden zaak , zich onthouden van iets , verboden als schadelijk , als onbetamelijk , verboden en ongeoorloofd bij een sterfgeval	forbidden thing , abstain from something , forbidden as harmful , as unbecoming , forbidden and unauthorised in case of death	èpahoäq	210	Epaho'a'	E p a h o ' a '	ɛ p a h o ʔ a ʔ						
+628	491	E	toornig , vertoornd , boos , vergramd	wrathful , wroth , angry , enraged	èpahoe(w)a		Epahu(w)a	E p a h u ( w ) a	ɛ p a h u ( w ) a						
+629	491	E	bedrog , list , streek	deception , trickery , prank	èpaienoä		Epaino'a	E p a i n o ' a	ɛ p a i n o ʔ a						
 630	491	E	een in het wild voorkomende kaneelboom	a wild cinnamon tree	èpaka		Epaka	E p a k a	ɛ p a k a						
 631	491	E	mes	knife	èpakamaie		Epakamai	E p a k a m a i	ɛ p a k a m a i						
 632	491	E	zoenoffer tot bijlegging van een familiegeschil	peace offering to settle a family dispute	èpakèlie		EpakEli	E p a k E l i	ɛ p a k ɛ l i						
-633	491	E	mast, paal, stijl	mast, pole, style	èpakoehè	99	EpakuhE	E p a k u h E	ɛ p a k u h ɛ						
+633	491	E	mast , paal , stijl	mast , pole , style	èpakoehè	99	EpakuhE	E p a k u h E	ɛ p a k u h ɛ						
 634	491	E	tripang	sea cucumber	èpakoeie		Epakui	E p a k u i	ɛ p a k u i						
-635	491	E	uit elkander, van elkander gescheiden	apart, separated	èpako(w)a	211	Epako(w)a	E p a k o ( w ) a	ɛ p a k o ( w ) a						
-636	492	E	zoowel nageboorte als het bloedstremsel, dat na de geboorte volgt	both afterbirth and the blood rennet that follows birth	èpalè	100	EpalE	E p a l E	ɛ p a l ɛ						
-637	492	E	geschrift, schrijven	writing, writing	èpananaö		Epanana'o	E p a n a n a ' o	ɛ p a n a n a ʔ o						
+635	491	E	uit elkander , van elkander gescheiden	apart , separated	èpako(w)a	211	Epako(w)a	E p a k o ( w ) a	ɛ p a k o ( w ) a						
+636	492	E	zoowel nageboorte als het bloedstremsel , dat na de geboorte volgt	both afterbirth and the blood rennet that follows birth	èpalè	100	EpalE	E p a l E	ɛ p a l ɛ						
+637	492	E	geschrift , schrijven	writing , writing	èpananaö		Epanana'o	E p a n a n a ' o	ɛ p a n a n a ʔ o						
 638	492	E	neus	nose	èpanoe	101	Epanu	E p a n u	ɛ p a n u						
 639	492	E	slaperig	sleepy	èpanoeka		Epanuka	E p a n u k a	ɛ p a n u k a						
 640	492	E	e. s. v. dissel	a sort of drawbar	èpanèma	212	EpanEma	E p a n E m a	ɛ p a n ɛ m a						
-641	492	E	achterzijde, rug	rear, back	èpaö		Epa'o	E p a ' o	ɛ p a ʔ o						
-642	492	E	vlinder, kapel	butterfly, chapel	èpaopa	103	Epaopa	E p a o p a	ɛ p a o p a						
+641	492	E	achterzijde , rug	rear , back	èpaö		Epa'o	E p a ' o	ɛ p a ʔ o						
+642	492	E	vlinder , kapel	butterfly , chapel	èpaopa	103	Epaopa	E p a o p a	ɛ p a o p a						
 643	492	E	schreeuwen van menschen en dieren	cries of people and animals	èpaoqöqaie	104	Epao'u̇'ai	E p a o ' u̇ ' a i	ɛ p a o ʔ ɨ ʔ a i						
-644	492	E	in, te, op	in, at, on	èpè		EpE	E p E	ɛ p ɛ						
-645	492	E	rand, boord, zoom, oever	edge, border, hem, bank	èpèa	105	EpEa	E p E a	ɛ p ɛ a						
+644	492	E	in , te , op	in , at , on	èpè		EpE	E p E	ɛ p ɛ						
+645	492	E	rand , boord , zoom , oever	edge , border , hem , bank	èpèa	105	EpEa	E p E a	ɛ p ɛ a						
 646	492	E	kokosmelk	coconut milk	èpèa(ie)ha		EpEa(i)ha	E p E a ( i ) h a	ɛ p ɛ a ( i ) h a						
 647	492	E	kapmes	machete	èpèdjie		EpEji	E p E j i	ɛ p ɛ d͡ʒ i						
 648	492	E	Palembangsch kapmes	Palembang machete	èpèdjiekèèqbara		EpEjikEE'bara	E p E j i k E E ' b a r a	ɛ p ɛ d͡ʒ i k ɛ ɛ ʔ b a r a						
 649	492	E	ster	star	èpèdo(w)a(ö)	213	EpEdo(w)a('o)	E p E d o ( w ) a ( ' o )	ɛ p ɛ d o ( w ) a ( ʔ o )						
-650	492	E	oorsprong, begin	origin, beginning	èpèhè	106	EpEhE	E p E h E	ɛ p ɛ h ɛ						
+650	492	E	oorsprong , begin	origin , beginning	èpèhè	106	EpEhE	E p E h E	ɛ p ɛ h ɛ						
 651	492	E	lever	liver	èpèkoe(w)aq		EpEku(w)a'	E p E k u ( w ) a '	ɛ p ɛ k u ( w ) a ʔ						
-652	492	E	maag, krop.	stomach, crop.	èpèkoeqwaq		EpEku'wa'	E p E k u ' w a '	ɛ p ɛ k u ʔ w a ʔ						
-653	492	E	keuvelen, praten	gabbing, talking	èpènaö		EpEna'o	E p E n a ' o	ɛ p ɛ n a ʔ o						
-654	492	E	bovenarm	upper arm	èpèrhaoedie	214	EpErhaudi	E p E r h a u d i	ɛ p ɛ r h a u d i	èoe(w)apo	Eu(w)apo	E u ( w ) a p o	573 ; 582	ɛ u ( w ) a p o	
+652	492	E	maag , krop.	stomach , crop.	èpèkoeqwaq		EpEku'wa'	E p E k u ' w a '	ɛ p ɛ k u ʔ w a ʔ						
+653	492	E	keuvelen , praten	gabbing , talking	èpènaö		EpEna'o	E p E n a ' o	ɛ p ɛ n a ʔ o						
+654	492	E	bovenarm	upper arm	èpèrhaoedie	214	EpErhaudi	E p E r h a u d i	ɛ p ɛ r h a u d i	èoe(w)apo	Eu(w)apo	E u ( w ) a p o	573	ɛ u ( w ) a p o	
+654	492	E	bovenarm	upper arm	èpèrhaoedie	214	EpErhaudi	E p E r h a u d i	ɛ p ɛ r h a u d i	èoe(w)apo	Eu(w)apo	E u ( w ) a p o	582	ɛ u ( w ) a p o	
 655	492	E	(mal.) aarden of metalen pot om in te koken	(mal.) earthen or metal pot for cooking	èpèrie(j)oq		EpEri(y)o'	E p E r i ( y ) o '	ɛ p ɛ r i ( j ) o ʔ	pĕrijoek	pėriyuk	p ė r i y u k	Malay crossref	p ə r i j u k	malay
 656	492	E	zekere pisangsoort	certain pisang species	èpieako(w)èq		Epiako(w)E'	E p i a k o ( w ) E '	ɛ p i a k o ( w ) ɛ ʔ						
 657	492	E	tusschenhandsbeenderen	metacarpal bones	èpieaoe(w)apo	215	Epiau(w)apo	E p i a u ( w ) a p o	ɛ p i a u ( w ) a p o						
-658	492	E	arm, armoedig	poor, shabby	èpiedjaja		Epijaya	E p i j a y a	ɛ p i d͡ʒ a j a						
+658	492	E	arm , armoedig	poor , shabby	èpiedjaja		Epijaya	E p i j a y a	ɛ p i d͡ʒ a j a						
 659	492	E	zekere boomsoort met deugdzaam timmerhout	certain tree species with decent lumber	èpiedjoe		Epiju	E p i j u	ɛ p i d͡ʒ u						
 660	492	E	eĕne liaansoort	eĕne liana species	èpiedjoeapo	216	Epijuapo	E p i j u a p o	ɛ p i d͡ʒ u a p o						
-661	492	E	zeeschuim	sea foam	èpieho; èpiehooe(è)oe(w)è		Epiho; Epihou(E)u(w)E	E p i h o ; # E p i h o u ( E ) u ( w ) E	ɛ p i ç o ; # ɛ p i ç o u ( ɛ ) u ( w ) ɛ						
-662	492	E	bouwland, tuin	arable land, garden	èpie(j)a	107	Epi(y)a	E p i ( y ) a	ɛ p i ( j ) a						
+661	492	E	zeeschuim	sea foam	èpieho		Epiho	E p i h o	ɛ p i ç o						
+661	492	E	zeeschuim	sea foam	èpiehooe(è)oe(w)è		Epihou(E)u(w)E	E p i h o u ( E ) u ( w ) E	ɛ p i ç o u ( ɛ ) u ( w ) ɛ						
+662	492	E	bouwland , tuin	arable land , garden	èpie(j)a	107	Epi(y)a	E p i ( y ) a	ɛ p i ( j ) a						
 663	492	E	kuit	calf	èpie(j)opie(j)o	108	Epi(y)opi(y)o	E p i ( y ) o p i ( y ) o	ɛ p i ( j ) o p i ( j ) o						
 664	492	E	manggistam	mango stem	èpieko		Epiko	E p i k o	ɛ p i k o						
-665	492	E	schaar, knipschaar	scissors, shears	èpienie		Epini	E p i n i	ɛ p i n i						
+665	492	E	schaar , knipschaar	scissors , shears	èpienie		Epini	E p i n i	ɛ p i n i						
 666	492	E	boomlooze vlakte	treeless plain	èpieniepie	110	Epinipi	E p i n i p i	ɛ p i n i p i						
 667	492	E	horizontale omwandingsplanken	horizontal wall boards	èpiepie	109	Epipi	E p i p i	ɛ p i p i						
 668	492	E	eene rottansoort	a rottan species	èpoäq		Epo'a'	E p o ' a '	ɛ p o ʔ a ʔ						
@@ -672,744 +689,756 @@ ID	page	entry	dutch	english	form	variant_ID	form_common_transcription	form_commo
 671	492	E	dooden van levende wezens	killing of living beings	èpoedoe	220	Epudu	E p u d u	ɛ p u d u						
 672	492	E	kruin in alle beteekenissen	crown in all meanings	èpoeha		Epuha	E p u h a	ɛ p u h a						
 673	492	E	eene mĕngkoedoesoort	a mengkudu species	èpoeiehoe		Epuihu	E p u i h u	ɛ p u i ç u						
-674	493	E	navel, navelstreng	navel, umbilical cord	èpoeko	112	Epuko	E p u k o	ɛ p u k o						
+674	493	E	navel , navelstreng	navel , umbilical cord	èpoeko	112	Epuko	E p u k o	ɛ p u k o						
 675	493	E	blad	leaf	èpoenoe		Epunu	E p u n u	ɛ p u n u						
 676	493	E	knie	knee	èpoeoe		Epu'u	E p u ' u	ɛ p u ʔ u						
 677	493	E	geleding	joint	èpoe(oe)qoe		Epu(u)'u	E p u ( u ) ' u	ɛ p u ( u ) ʔ u						
-678	493	E	pols	wrist	èpoe(oe)qoe: oe(w)apo	219	Epu(u)'u: u(w)apo	E p u ( u ) ' u : # u ( w ) a p o	ɛ p u ( u ) ʔ u : # u ( w ) a p o						
+678	493	E	pols	wrist	èpoe(oe)qoe:_oe(w)apo	219	Epu(u)'u:_u(w)apo	E p u ( u ) ' u : _ u ( w ) a p o	ɛ p u ( u ) ʔ u : _ u ( w ) a p o						
 679	493	E	enkel	ankle	oe(w)aie		u(w)ai	u ( w ) a i	u ( w ) a i						
-680	493	E	haarvederen; schaamharen	hair feathers; pubic hairs	èpoeroedoe(ie)	221	Epurudu(i)	E p u r u d u ( i )	ɛ p u r u d u ( i )						
-681	493	E	hoofdhaar	head hair	èpoeroedoe(ie): èoedoe	223	Epurudu(i): Eudu	E p u r u d u ( i ) : # E u d u	ɛ p u r u d u ( i ) : # ɛ u d u						
+680	493	E	haarvederen ; schaamharen	hair feathers ; pubic hairs	èpoeroedoe(ie)	221	Epurudu(i)	E p u r u d u ( i )	ɛ p u r u d u ( i )						
+681	493	E	hoofdhaar	head hair	èpoeroedoe(ie):_èoedoe	223	Epurudu(i):_Eudu	E p u r u d u ( i ) : _ E u d u	ɛ p u r u d u ( i ) : _ ɛ u d u						
 682	493	E	oogharen	eyelashes	oebaka		ubaka	u b a k a	u b a k a						
 683	493	E	dakbedekking van bladeren	roofing leaves	èpoeroedoe(ie)	222	Epurudu(i)	E p u r u d u ( i )	ɛ p u r u d u ( i )						
-684	493	E	dakbedekking van pandanusbladeren	roofing made of pandanus leaves	èpoeroedoe(ie): aniemaie	224	Epurudu(i): animai	E p u r u d u ( i ) : # a n i m a i	ɛ p u r u d u ( i ) : # a n i m a i						
+684	493	E	dakbedekking van pandanusbladeren	roofing made of pandanus leaves	èpoeroedoe(ie):_aniemaie	224	Epurudu(i):_animai	E p u r u d u ( i ) : _ a n i m a i	ɛ p u r u d u ( i ) : _ a n i m a i						
 685	493	E	dakbedekking van nipabladeren	roofing of nipa leaves	èko(ö)qko(ö)q		Eko('o)'ko('o)'	E k o ( ' o ) ' k o ( ' o ) '	ɛ k o ( ʔ o ) ʔ k o ( ʔ o ) ʔ						
-686	493	E	bedeksel van rottanbladeren, eertijds door de vrouwen om’ den middel gedragen gedurende den rouwtijd	cover of rattan leaves, once worn around the waist by women during the mourning period	oeietjo	437	uico	u i c o	u i t͡ʃ o						
-687	493	E	teeken, merkteeken, uiterlijk voorkomen, zichtbare gedaante	sign, mark, outward appearance, visible form	èpo(ah)ha	217	Epo(ah)ha	E p o ( a h ) h a	ɛ p o ( a h ) h a						
+686	493	E	bedeksel van rottanbladeren , eertijds door de vrouwen om’ den middel gedragen gedurende den rouwtijd	cover of rattan leaves , once worn around the waist by women during the mourning period	oeietjo	437	uico	u i c o	u i t͡ʃ o						
+687	493	E	teeken , merkteeken , uiterlijk voorkomen , zichtbare gedaante	sign , mark , outward appearance , visible form	èpo(ah)ha	217	Epo(ah)ha	E p o ( a h ) h a	ɛ p o ( a h ) h a						
 688	493	E	kokospalm	coconut palm	èpoh	111	Epoh	E p o h	ɛ p o h						
 689	493	E	plant met eetbaren knol	plant with edible tuber	èpohkèaq		EpohkEa'	E p o h k E a '	ɛ p o h k ɛ a ʔ	kĕladie	kėladi	k ė l a d i	Malay crossref	k ə l a d i	
-690	493	E	in, binnen in	in, inside	èpoko	113	Epoko	E p o k o	ɛ p o k o						
-691	493	E	jonge man, jongmensch	young man, young person	èponanamè	225	EponanamE	E p o n a n a m E	ɛ p o n a n a m ɛ						
-692	493	E	spin, spinneweb	spider, spider web	èpo(ö)kaha	218	Epo('o)kaha	E p o ( ' o ) k a h a	ɛ p o ( ʔ o ) k a h a						
-693	493	E	schieten, schietgeweer	shooting, shotgun	èpoökie	226	Epo'oki	E p o ' o k i	ɛ p o ʔ o k i						
+690	493	E	in , binnen in	in , inside	èpoko	113	Epoko	E p o k o	ɛ p o k o						
+691	493	E	jonge man , jongmensch	young man , young person	èponanamè	225	EponanamE	E p o n a n a m E	ɛ p o n a n a m ɛ						
+692	493	E	spin , spinneweb	spider , spider web	èpo(ö)kaha	218	Epo('o)kaha	E p o ( ' o ) k a h a	ɛ p o ( ʔ o ) k a h a						
+693	493	E	schieten , schietgeweer	shooting , shotgun	èpoökie	226	Epo'oki	E p o ' o k i	ɛ p o ʔ o k i						
 694	493	E	asch	ash	èpoqa		Epo'a	E p o ' a	ɛ p o ʔ a						
-695	493	E	jong meisje, maagd	young girl, virgin	èpo(q)ienamo		Epo(')inamo	E p o ( ' ) i n a m o	ɛ p o ( ʔ ) i n a m o						
+695	493	E	jong meisje , maagd	young girl , virgin	èpo(q)ienamo		Epo(')inamo	E p o ( ' ) i n a m o	ɛ p o ( ʔ ) i n a m o						
 696	493	E	zekere boomsoort met deugdzaam timmerhout	certain tree species with decent lumber	èporo		Eporo	E p o r o	ɛ p o r o						
 697	493	E	testikel	testicle	(èq)èhoenè		(E')EhunE	( E ' ) E h u n E	( ɛ ʔ ) ɛ h u n ɛ						
-698	493	E	boven, bovenste oppervlakte, hoog	above, upper surface, high	ètèbè	285	EtEbE	E t E b E	ɛ t ɛ b ɛ						
-699	493	E	benauwd, beklemd, aamborstig	cramped, constricted, short of breath	èwakiepöro	232	Ewakipu̇ro	E w a k i p u̇ r o	ɛ w a k i p ɨ r o						
+698	493	E	boven , bovenste oppervlakte , hoog	above , upper surface , high	ètèbè	285	EtEbE	E t E b E	ɛ t ɛ b ɛ						
+699	493	E	benauwd , beklemd , aamborstig	cramped , constricted , short of breath	èwakiepöro	232	Ewakipu̇ro	E w a k i p u̇ r o	ɛ w a k i p ɨ r o						
 700	493	G	(mal.) , zout	(mal.) , salt	garam		garam	g a r a m	g a r a m						malay
-701	493	G	(mal.), onderwijzer	(mal.), teacher	goeroe		guru	g u r u	g u r u						malay
+701	493	G	(mal.) , onderwijzer	(mal.) , teacher	goeroe		guru	g u r u	g u r u						malay
 702	493	H	het mal. achtervoegsel	the Malay suffix	ha		ha	h a	h a	lah	lah	l a h	Malay crossref	l a h	
 703	493	H	eene lengtemaat gelijkstaande met twaalf vadem	a length equivalent to twelve fathoms	habakao		habakao	h a b a k a o	h a b a k a o						
-704	493	H	samenverbonden, zooals een rist uien, bladeren aan een tak, vruchten aan een steel	joined together, like a string of onions, leaves on a branch, fruit on a stem	haboejaq		habuya'	h a b u y a '	h a b u j a ʔ						
-705	493	H	wat, wie, wie ook, hoe	what, who, whoever, how	haie		hai	h a i	h a i						
+704	493	H	samenverbonden , zooals een rist uien , bladeren aan een tak , vruchten aan een steel	joined together , like a string of onions , leaves on a branch , fruit on a stem	haboejaq		habuya'	h a b u y a '	h a b u j a ʔ						
+705	493	H	wat , wie , wie ook , hoe	what , who , whoever , how	haie		hai	h a i	h a i						
 706	493	H	waar	where	haiejaha		haiyaha	h a i y a h a	h a i j a h a						
 707	493	H	waar ter plaatse	whereabouts	abahaiejaha		abahaiyaha	a b a h a i y a h a	a b a h a i j a h a						
 708	493	H	waarheen	where to	kahaiejaha		kahaiyaha	k a h a i y a h a	k a h a i j a h a						
-709	493	H	eerst, eertijds	first, once	halè		halE	h a l E	h a l ɛ						
+709	493	H	eerst , eertijds	first , once	halè		halE	h a l E	h a l ɛ						
 710	494	H	insnijden	cut into	hamèhènie		hamEhEni	h a m E h E n i	h a m ɛ h ɛ n i						
 711	494	H	bijten van menschen en dieren	biting of humans and animals	haoe		hau	h a u	h a u						
-712	494	H	betasten, aanvatten	touch, grab	hèdapiehie	270	hEdapihi	h E d a p i h i	h ɛ d a p i ç i						
+712	494	H	betasten , aanvatten	touch , grab	hèdapiehie	270	hEdapihi	h E d a p i h i	h ɛ d a p i ç i						
 713	494	H	achterste van dieren	hindquarters of animals	hèie(j)o		hEi(y)o	h E i ( y ) o	h ɛ i ( j ) o						
-714	494	H	met, door middel van; ons: plus	with, by means of; us: plus	hie		hi	h i	h i						
-715	494	H	de achterkant, de keerzijde, omgekeerd, terug, naar huis terug, weder terugkeeren	the reverse, the reverse, reverse, back, return home, return again	hiebaie		hibai	h i b a i	h i b a i						
-716	494	H	nu en dan, somtijds	now and then, sometimes	hieie(j)oie(j)o		hii(y)oi(y)o	h i i ( y ) o i ( y ) o	h i i ( j ) o i ( j ) o						
-717	494	H	krabben, graven met de handen	scratching, digging with hands	hie(j)onie		hi(y)oni	h i ( y ) o n i	h i ( j ) o n i						
-718	494	H	dikwijls, vaak	frequently, often	hienoea		hinua	h i n u a	h i n u a						
-719	494	H	reeds, ook gebruikt tot vorming van den volkomen verleden tijd	already, also used to form the perfect past tense	ho		ho	h o	h o						
-720	494	H	tot aan toe, er toe komen, bereikt worden	up to, getting there, being reached	hoäkoqaq		ho'ako'a'	h o ' a k o ' a '	h o ʔ a k o ʔ a ʔ						
-721	494	H	verzadigd, voldaan	saturated, satisfied	hobaäoeie(j)aka		hoba'aui(y)aka	h o b a ' a u i ( y ) a k a	h o b a ʔ a u i ( j ) a k a						
-722	494	H	zuiver, helder, zindelijk	pure, clear, clean	hobaäoe(w)a	271	hoba'au(w)a	h o b a ' a u ( w ) a	h o b a ʔ a u ( w ) a						
-723	494	H	bedaard, tot rust gekomen, opgehouden (van den regen)	calmed down, settled down, stopped (of the rain)	hobahaba		hobahaba	h o b a h a b a	h o b a h a b a						
-724	494	H	makker, kameraad	companion, comrade	hobèèaö	428	hobEEa'o	h o b E E a ' o	h o b ɛ ɛ a ʔ o						
-725	494	H	tevreden, welbehagelijk	contented, agreeable	hoboek		hobuk	h o b u k	h o b u k						
-726	494	H	verbruikt, reeds, ten einde	consumed, already, at the end	hödahöda		hu̇dahu̇da	h u̇ d a h u̇ d a	h ɨ d a h ɨ d a						
-727	494	H	hersteld, weer beter	recovered, better again	hodiedieka		hodidika	h o d i d i k a	h o d i d i k a						
-728	494	H	boor, gedraaid, gewonden	drill, twisted, wound	hodiekie	275	hodiki	h o d i k i	h o d i k i						
-729	494	H	behoorlijk, passend, betamelijk	decent, appropriate, proper	hoèana		huana	h u a n a	h u a n a						
+714	494	H	met , door middel van ; ons : plus	with , by means of ; us : plus	hie		hi	h i	h i						
+715	494	H	de achterkant , de keerzijde , omgekeerd , terug , naar huis terug , weder terugkeeren	the reverse , the reverse , reverse , back , return home , return again	hiebaie		hibai	h i b a i	h i b a i						
+716	494	H	nu en dan , somtijds	now and then , sometimes	hieie(j)oie(j)o		hii(y)oi(y)o	h i i ( y ) o i ( y ) o	h i i ( j ) o i ( j ) o						
+717	494	H	krabben , graven met de handen	scratching , digging with hands	hie(j)onie		hi(y)oni	h i ( y ) o n i	h i ( j ) o n i						
+718	494	H	dikwijls , vaak	frequently , often	hienoea		hinua	h i n u a	h i n u a						
+719	494	H	reeds , ook gebruikt tot vorming van den volkomen verleden tijd	already , also used to form the perfect past tense	ho		ho	h o	h o						
+720	494	H	tot aan toe , er toe komen , bereikt worden	up to , getting there , being reached	hoäkoqaq		ho'ako'a'	h o ' a k o ' a '	h o ʔ a k o ʔ a ʔ						
+721	494	H	verzadigd , voldaan	saturated , satisfied	hobaäoeie(j)aka		hoba'aui(y)aka	h o b a ' a u i ( y ) a k a	h o b a ʔ a u i ( j ) a k a						
+722	494	H	zuiver , helder , zindelijk	pure , clear , clean	hobaäoe(w)a	271	hoba'au(w)a	h o b a ' a u ( w ) a	h o b a ʔ a u ( w ) a						
+723	494	H	bedaard , tot rust gekomen , opgehouden (van den regen)	calmed down , settled down , stopped (of the rain)	hobahaba		hobahaba	h o b a h a b a	h o b a h a b a						
+724	494	H	makker , kameraad	companion , comrade	hobèèaö	428	hobEEa'o	h o b E E a ' o	h o b ɛ ɛ a ʔ o						
+725	494	H	tevreden , welbehagelijk	contented , agreeable	hoboek		hobuk	h o b u k	h o b u k						
+726	494	H	verbruikt , reeds , ten einde	consumed , already , at the end	hödahöda		hu̇dahu̇da	h u̇ d a h u̇ d a	h ɨ d a h ɨ d a						
+727	494	H	hersteld , weer beter	recovered , better again	hodiedieka		hodidika	h o d i d i k a	h o d i d i k a						
+728	494	H	boor , gedraaid , gewonden	drill , twisted , wound	hodiekie	275	hodiki	h o d i k i	h o d i k i						
+729	494	H	behoorlijk , passend , betamelijk	decent , appropriate , proper	hoèana		huana	h u a n a	h u a n a						
 730	494	H	haar	hair / her	hoeka		huka	h u k a	h u k a						
-731	494	H	eene heilige plaats, waar de meeste geesten verblijven	a holy place, where most spirits reside	hoeko(q)ä	274	huko(')a	h u k o ( ' ) a	h u k o ( ʔ ) a						
+731	494	H	eene heilige plaats , waar de meeste geesten verblijven	a holy place , where most spirits reside	hoeko(q)ä	274	huko(')a	h u k o ( ' ) a	h u k o ( ʔ ) a						
 732	494	H	soekoe (stam)	suku (tribe)	hoeoenoeka		hu'unuka	h u ' u n u k a	h u ʔ u n u k a						
-733	494	H	van den grond oprapen, plukken	picking up from the ground, plucking	hoie		hoi	h o i	h o i						
+733	494	H	van den grond oprapen , plukken	picking up from the ground , plucking	hoie		hoi	h o i	h o i						
 734	494	H	slachten van een dier	slaughter of an animal	höka		hu̇ka	h u̇ k a	h ɨ k a						
-735	494	H	krabben, graven met de handen	scratching, digging with hands	homaie		homai	h o m a i	h o m a i						
+735	494	H	krabben , graven met de handen	scratching , digging with hands	homaie		homai	h o m a i	h o m a i						
 736	494	H	ochtendstond	dawn	homanieka		homanika	h o m a n i k a	h o m a n i k a						
-737	494	H	getrouwde man, echtgenoot	married man, husband	hona(o)		hona(o)	h o n a ( o )	h o n a ( o )						
-738	494	H	worden, geworden zijn, geboren worden, ontstaan, groeien	becoming, having become, being born, arising, growing	honoaha		honoaha	h o n o a h a	h o n o a h a						
+737	494	H	getrouwde man , echtgenoot	married man , husband	hona(o)		hona(o)	h o n a ( o )	h o n a ( o )						
+738	494	H	worden , geworden zijn , geboren worden , ontstaan , groeien	becoming , having become , being born , arising , growing	honoaha		honoaha	h o n o a h a	h o n o a h a						
 739	494	H	schoot	lap / shot	hopaie	272	hopai	h o p a i	h o p a i						
-740	494	H	overeenkomst, verbintenis, afspraak, belofte	agreement, commitment, arrangement, promise	hopanao		hopanao	h o p a n a o	h o p a n a o						
-741	494	IE	bij, op, naar	at, on, to	ie		i	i	i						
-742	494	IE	slaan, kloppen met iets	hitting, knocking with something	iedjie		iji	i j i	i d͡ʒ i						
-743	494	IE	in, binnen	in, within	ieho		iho	i h o	i ç o						
-744	494	IE	binnen drie dagen	within three days	ieho akoloe poq		iho akolu po'	i h o # a k o l u # p o '	i ç o # a k o l u # p o ʔ						
+740	494	H	overeenkomst , verbintenis , afspraak , belofte	agreement , commitment , arrangement , promise	hopanao		hopanao	h o p a n a o	h o p a n a o						
+741	494	IE	bij , op , naar	at , on , to	ie		i	i	i						
+742	494	IE	slaan , kloppen met iets	hitting , knocking with something	iedjie		iji	i j i	i d͡ʒ i						
+743	494	IE	in , binnen	in , within	ieho		iho	i h o	i ç o						
+744	494	IE	binnen drie dagen	within three days	ieho_akoloe_poq		iho_akolu_po'	i h o _ a k o l u _ p o '	i ç o _ a k o l u _ p o ʔ						
 745	494	IE	daarbinnen	within that	iehoie(j)ana		ihoi(y)ana	i h o i ( y ) a n a	i ç o i ( j ) a n a						
-746	495	IE	kracht, krachtig, sterk	force, powerful, strong	ie(j)aäo		i(y)a'ao	i ( y ) a ' a o	i ( j ) a ʔ a o						
-747	495	IE	geschild, gepeld, gevild	peeled, skinned	ie(j)abie		i(y)abi	i ( y ) a b i	i ( j ) a b i						
+746	495	IE	kracht , krachtig , sterk	force , powerful , strong	ie(j)aäo		i(y)a'ao	i ( y ) a ' a o	i ( j ) a ʔ a o						
+747	495	IE	geschild , gepeld , gevild	peeled , skinned	ie(j)abie		i(y)abi	i ( y ) a b i	i ( j ) a b i						
 748	495	IE	zie haie	see “haie”	ie(j)aha(ie)	269	i(y)aha(i)	i ( y ) a h a ( i )	i ( j ) a h a ( i )	haie	hai	h a i	705	h a i	
 749	495	IE	gezegd van iemand die tot een andere «soekoe» dan de zijne behoort	said of someone who belongs to a “suku” other than his own	ie(j)ahaoeoeaq		i(y)ahau'ua'	i ( y ) a h a u ' u a '	i ( j ) a h a u ʔ u a ʔ						
-750	495	IE	hiel; met de hielen trappen	heel; kicking with the heels	ie(j)o		i(y)o	i ( y ) o	i ( j ) o						
-751	495	IE	dan, bij den vergelijkenden trap	than, for comparisons	ie(j)oho		i(y)oho	i ( y ) o h o	i ( j ) o h o						
-752	495	IE	ondiep, niet diep	shallow, not deep	ie(j)okie		i(y)oki	i ( y ) o k i	i ( j ) o k i						
+750	495	IE	hiel ; met de hielen trappen	heel ; kicking with the heels	ie(j)o		i(y)o	i ( y ) o	i ( j ) o						
+751	495	IE	dan , bij den vergelijkenden trap	than , for comparisons	ie(j)oho		i(y)oho	i ( y ) o h o	i ( j ) o h o						
+752	495	IE	ondiep , niet diep	shallow , not deep	ie(j)okie		i(y)oki	i ( y ) o k i	i ( j ) o k i						
 753	495	IE	N. N.	Nomen Nescio (name unknown)	ie(j)omoö		i(y)omo'o	i ( y ) o m o ' o	i ( j ) o m o ʔ o						
-754	495	IE	in of door iets heen steken of graven of peuteren, delven, opdelven	sticking or digging or probing into or through something, delving, digging up	ie(j)onie	283	i(y)oni	i ( y ) o n i	i ( j ) o n i						
-755	495	IE	door, uit kracht van	by, by force of	ie(j)onie(j)a		i(y)oni(y)a	i ( y ) o n i ( y ) a	i ( j ) o n i ( j ) a						
+754	495	IE	in of door iets heen steken of graven of peuteren , delven , opdelven	sticking or digging or probing into or through something , delving , digging up	ie(j)onie	283	i(y)oni	i ( y ) o n i	i ( j ) o n i						
+755	495	IE	door , uit kracht van	by , by force of	ie(j)onie(j)a		i(y)oni(y)a	i ( y ) o n i ( y ) a	i ( j ) o n i ( j ) a						
 756	495	IE	wij	we	ieka		ika	i k a	i k a						
 757	495	IE	daarbuiten	beyond	iekahaö		ikaha'o	i k a h a ' o	i k a h a ʔ o						
-758	495	IE	met opzet, willens, opzettelijk	intentionally, knowingly, deliberately	iekahoboe(w)ara		ikahobu(w)ara	i k a h o b u ( w ) a r a	i k a h o b u ( w ) a r a						
-759	495	IE	benevens, met	besides, with	iekara		ikara	i k a r a	i k a r a						
+758	495	IE	met opzet , willens , opzettelijk	intentionally , knowingly , deliberately	iekahoboe(w)ara		ikahobu(w)ara	i k a h o b u ( w ) a r a	i k a h o b u ( w ) a r a						
+759	495	IE	benevens , met	besides , with	iekara		ikara	i k a r a	i k a r a						
 760	495	IE	niet goed kunnen zien	not being able to see well	iekoedoha	281	ikudoha	i k u d o h a	i k u d o h a						
-761	495	IE	achterzijde, rug	rear, back	iekoeko		ikuko	i k u k o	i k u k o						
-762	495	IE	omhoog, omhoog gaan, klimmen	up, going up, climbing	ienaou(w)a	282	inaou(w)a	i n a o u ( w ) a	i n a o u ( w ) a						
+761	495	IE	achterzijde , rug	rear , back	iekoeko		ikuko	i k u k o	i k u k o						
+762	495	IE	omhoog , omhoog gaan , klimmen	up , going up , climbing	ienaou(w)a	282	inaou(w)a	i n a o u ( w ) a	i n a o u ( w ) a						
 763	495	IE	zoeken	search	ienoenoeq	413	inunu'	i n u n u '	i n u n u ʔ						
-764	495	IE	een gat graven, maken	dig a hole, make a hole	ienoqie		ino'i	i n o ' i	i n o ʔ i						
-765	495	IE	opdat, ten einde	so that, in order	ietaqoe(w)a		ita'u(w)a	i t a ' u ( w ) a	i t a ʔ u ( w ) a						
-766	495	IE	die, dat	which, that	ietèq		itE'	i t E '	i t ɛ ʔ						
+764	495	IE	een gat graven , maken	dig a hole , make a hole	ienoqie		ino'i	i n o ' i	i n o ʔ i						
+765	495	IE	opdat , ten einde	so that , in order	ietaqoe(w)a		ita'u(w)a	i t a ' u ( w ) a	i t a ʔ u ( w ) a						
+766	495	IE	die , dat	which , that	ietèq		itE'	i t E '	i t ɛ ʔ						
 767	495	IE	drinken	drink	ietjo	279	ico	i c o	i t͡ʃ o						
-768	495	IE	argwaan, verdenking, vermoeden	suspicion, suspicion	ietjoehaq		icuha'	i c u h a '	i t͡ʃ u h a ʔ						
+768	495	IE	argwaan , verdenking , vermoeden	suspicion , suspicion	ietjoehaq		icuha'	i c u h a '	i t͡ʃ u h a ʔ						
 769	495	K	wij (met insluiting van den aangesproken persoon)	we (including the person addressed)	ka		ka	k a	k a						
-770	495	K	dood, einde, gaan liggen van den wind	death, end, dying down of the wind	kaä		ka'a	k a ' a	k a ʔ a						
-771	495	K	onbewoond, eenzaam, verlaten	uninhabited, lonely, abandoned	kaäämie		ka'a'ami	k a ' a ' a m i	k a ʔ a ʔ a m i						
-772	495	K	dik, vet, zwaarlijvig, vet van menschen en dieren	fat, fat, obese, fat of humans and animals	kaä(ä)oe(w)a	287	ka'a('a)u(w)a	k a ' a ( ' a ) u ( w ) a	k a ʔ a ( ʔ a ) u ( w ) a						
+770	495	K	dood , einde , gaan liggen van den wind	death , end , dying down of the wind	kaä		ka'a	k a ' a	k a ʔ a						
+771	495	K	onbewoond , eenzaam , verlaten	uninhabited , lonely , abandoned	kaäämie		ka'a'ami	k a ' a ' a m i	k a ʔ a ʔ a m i						
+772	495	K	dik , vet , zwaarlijvig , vet van menschen en dieren	fat , fat , obese , fat of humans and animals	kaä(ä)oe(w)a	287	ka'a('a)u(w)a	k a ' a ( ' a ) u ( w ) a	k a ʔ a ( ʔ a ) u ( w ) a						
 773	495	K	bitter van smaak	bitter in taste	kaädahoaie	295	ka'adahoai	k a ' a d a h o a i	k a ʔ a d a h o a i						
-774	495	K	opgelost, verteerd	dissolved, digested	kaädodie		ka'adodi	k a ' a d o d i	k a ʔ a d o d i						
-775	495	K	nog meer, nog steeds	even more, still	kaädo(j)a	288	ka'ado(y)a	k a ' a d o ( y ) a	k a ʔ a d o ( j ) a						
+774	495	K	opgelost , verteerd	dissolved , digested	kaädodie		ka'adodi	k a ' a d o d i	k a ʔ a d o d i						
+775	495	K	nog meer , nog steeds	even more , still	kaädo(j)a	288	ka'ado(y)a	k a ' a d o ( y ) a	k a ʔ a d o ( j ) a						
 776	495	K	oude vrouw	old woman	kaähoeöie		ka'ahu'oi	k a ' a h u ' o i	k a ʔ a h u ʔ o i						
 777	495	K	een der typen van eene Engganeesche lans	one of the types of an Engganese lance	kaäjoq		ka'ayo'	k a ' a y o '	k a ʔ a j o ʔ						
-778	495	K	bevrucht, zwanger, drachtig	fertilised, pregnant, gestating	ka(ä)kèo		ka('a)kEo	k a ( ' a ) k E o	k a ( ʔ a ) k ɛ o						
-779	495	K	gierig, vasthoudend, karig, vrekkig	stingy, tenacious, frugal, stingy	kaäkèho		ka'akEho	k a ' a k E h o	k a ʔ a k ɛ h o						
-780	496	K	droog, uitgedroogd	dry, dehydrated	kaäkie		ka'aki	k a ' a k i	k a ʔ a k i						
-781	496	K	meer, over, te veel, overschot	more, left over, too much, surplus	kaäkieè		ka'akiE	k a ' a k i E	k a ʔ a k i ɛ						
-782	496	K	het gevoel in de tanden, wanneer ze met iets zuurs in aanraking komen	the feeling in the teeth when they come into contact with something acidic	kaäkiekie(j)ĕ		ka'akiki(y)ė	k a ' a k i k i ( y ) ė	k a ʔ a k i k i ( j ) ə						
-783	496	K	blauw, donkerblauw	blue, dark blue	kaäkienafah		ka'akinafah	k a ' a k i n a f a h	k a ʔ a k i n a f a h						
-784	496	K	gew. verbonden met: «èbaka»; blind.	usually connected with: “èbaka”; blind	kaäkienè	290	ka'akinE	k a ' a k i n E	k a ʔ a k i n ɛ	èbaka	Ebaka	E b a k a	214 ; 215 ; 234	ɛ b a k a	
+778	495	K	bevrucht , zwanger , drachtig	fertilised , pregnant , gestating	ka(ä)kèo		ka('a)kEo	k a ( ' a ) k E o	k a ( ʔ a ) k ɛ o						
+779	495	K	gierig , vasthoudend , karig , vrekkig	stingy , tenacious , frugal , stingy	kaäkèho		ka'akEho	k a ' a k E h o	k a ʔ a k ɛ h o						
+780	496	K	droog , uitgedroogd	dry , dehydrated	kaäkie		ka'aki	k a ' a k i	k a ʔ a k i						
+781	496	K	meer , over , te veel , overschot	more , left over , too much , surplus	kaäkieè		ka'akiE	k a ' a k i E	k a ʔ a k i ɛ						
+782	496	K	het gevoel in de tanden , wanneer ze met iets zuurs in aanraking komen	the feeling in the teeth when they come into contact with something acidic	kaäkiekie(j)ĕ		ka'akiki(y)ė	k a ' a k i k i ( y ) ė	k a ʔ a k i k i ( j ) ə						
+783	496	K	blauw , donkerblauw	blue , dark blue	kaäkienafah		ka'akinafah	k a ' a k i n a f a h	k a ʔ a k i n a f a h						
+784	496	K	gew. verbonden met : «èbaka» ; blind.	usually connected with : “èbaka” ; blind	kaäkienè	290	ka'akinE	k a ' a k i n E	k a ʔ a k i n ɛ	èbaka	Ebaka	E b a k a	214	ɛ b a k a	
+784	496	K	gew. verbonden met : «èbaka» ; blind.	usually connected with : “èbaka” ; blind	kaäkienè	290	ka'akinE	k a ' a k i n E	k a ʔ a k i n ɛ	èbaka	Ebaka	E b a k a	215	ɛ b a k a	
+784	496	K	gew. verbonden met : «èbaka» ; blind.	usually connected with : “èbaka” ; blind	kaäkienè	290	ka'akinE	k a ' a k i n E	k a ʔ a k i n ɛ	èbaka	Ebaka	E b a k a	234	ɛ b a k a	
 785	496	K	groen	green	kaäkieniepa	291	ka'akinipa	k a ' a k i n i p a	k a ʔ a k i n i p a						
-786	496	K	kracht, krachtig, sterk	force, powerful, strong	kaäkoeka(h)		ka'akuka(h)	k a ' a k u k a ( h )	k a ʔ a k u k a ( h )						
-787	496	K	zwart, donkerkleurig	black, dark-coloured	kaäkoho		ka'akoho	k a ' a k o h o	k a ʔ a k o h o						
+786	496	K	kracht , krachtig , sterk	force , powerful , strong	kaäkoeka(h)		ka'akuka(h)	k a ' a k u k a ( h )	k a ʔ a k u k a ( h )						
+787	496	K	zwart , donkerkleurig	black , dark-coloured	kaäkoho		ka'akoho	k a ' a k o h o	k a ʔ a k o h o						
 788	496	K	snijden van rottan	cutting of rottan	kaämie		ka'ami	k a ' a m i	k a ʔ a m i						
-789	496	K	uitgebluscht van vuur of licht	extinguished, of fire or light	kaäoe		ka'au	k a ' a u	k a ʔ a u						
-790	496	K	lucht, reuk, geur (onaangenaam)	air, smell, odour (unpleasant)	kaäpaoe		ka'apau	k a ' a p a u	k a ʔ a p a u						
+789	496	K	uitgebluscht van vuur of licht	extinguished , of fire or light	kaäoe		ka'au	k a ' a u	k a ʔ a u						
+790	496	K	lucht , reuk , geur (onaangenaam)	air , smell , odour (unpleasant)	kaäpaoe		ka'apau	k a ' a p a u	k a ʔ a p a u						
 791	496	K	zoet van water	fresh water	kaäpèaäaq	293	ka'apEa'aa'	k a ' a p E a ' a a '	k a ʔ a p ɛ a ʔ a a ʔ						
-792	496	K	breed, ruim, uitgestrekt	wide, spacious, expansive	kaäpoho	289	ka'apoho	k a ' a p o h o	k a ʔ a p o h o						
-793	496	K	ebbe, vallen van het water	ebb, falling of the water	kababahaq		kababaha'	k a b a b a h a '	k a b a b a h a ʔ						
+792	496	K	breed , ruim , uitgestrekt	wide , spacious , expansive	kaäpoho	289	ka'apoho	k a ' a p o h o	k a ʔ a p o h o						
+793	496	K	ebbe , vallen van het water	ebb , falling of the water	kababahaq		kababaha'	k a b a b a h a '	k a b a b a h a ʔ						
 794	496	K	de papaja	the papaya	kabáèlo		kabaElo	k a b a E l o	k a b a ɛ l o						
 795	496	K	op weg ergens aangaan of bij iemand vertoeven	heading somewhere or staying with someone	kabahoa	296	kabahoa	k a b a h o a	k a b a h o a						
-796	496	K	snugger, schrander, verstandig, slim	savvy, astute, sensible, clever	kabahöjaäq		kabahu̇ya'a'	k a b a h u̇ y a ' a '	k a b a h ɨ j a ʔ a ʔ						
+796	496	K	snugger , schrander , verstandig , slim	savvy , astute , sensible , clever	kabahöjaäq		kabahu̇ya'a'	k a b a h u̇ y a ' a '	k a b a h ɨ j a ʔ a ʔ						
 797	496	K	geankerd zijn	be anchored	kabakoä		kabako'a	k a b a k o ' a	k a b a k o ʔ a						
-798	496	K	onrecht, onrechtmatige behandeling, kwaad doen, kwaad berokkenen van geesten	injustice, wrongful treatment, doing evil, harming spirits	kabatjoä		kabaco'a	k a b a c o ' a	k a b a t͡ʃ o ʔ a						
+798	496	K	onrecht , onrechtmatige behandeling , kwaad doen , kwaad berokkenen van geesten	injustice , wrongful treatment , doing evil , harming spirits	kabatjoä		kabaco'a	k a b a c o ' a	k a b a t͡ʃ o ʔ a						
 799	496	K	het uitkomen van een ei	the hatching of an egg	kabĕa		kabėa	k a b ė a	k a b ə a						
-800	496	K	stelen, heimelijk wegnemen	steal, surreptitiously take away	kabèhoq		kabEho'	k a b E h o '	k a b ɛ h o ʔ						
+800	496	K	stelen , heimelijk wegnemen	steal , surreptitiously take away	kabèhoq		kabEho'	k a b E h o '	k a b ɛ h o ʔ						
 801	496	K	vredeteeken	peace sign	kabiekaka		kabikaka	k a b i k a k a	k a b i k a k a						
 802	496	K	gevlekt	spotted	kabiekèbie		kabikEbi	k a b i k E b i	k a b i k ɛ b i						
-803	496	K	rond, ovaal	round, oval	kaboe(w)aboe(w)a	297	kabu(w)abu(w)a	k a b u ( w ) a b u ( w ) a	k a b u ( w ) a b u ( w ) a						
+803	496	K	rond , ovaal	round , oval	kaboe(w)aboe(w)a	297	kabu(w)abu(w)a	k a b u ( w ) a b u ( w ) a	k a b u ( w ) a b u ( w ) a						
 804	496	K	weduwe	widow	kaboekoe		kabuku	k a b u k u	k a b u k u						
-805	496	K	stinkend, verrot, bedorven	smelly, rotten, spoiled	kadèadèa	317	kadEadEa	k a d E a d E a	k a d ɛ a d ɛ a						
-806	496	K	gemakkelijk	easy, easily	kadèda		kadEda	k a d E d a	k a d ɛ d a						
-807	496	K	vol, verzadigd	full, saturated	kadèdè		kadEdE	k a d E d E	k a d ɛ d ɛ						
+805	496	K	stinkend , verrot , bedorven	smelly , rotten , spoiled	kadèadèa	317	kadEadEa	k a d E a d E a	k a d ɛ a d ɛ a						
+806	496	K	gemakkelijk	easy , easily	kadèda		kadEda	k a d E d a	k a d ɛ d a						
+807	496	K	vol , verzadigd	full , saturated	kadèdè		kadEdE	k a d E d E	k a d ɛ d ɛ						
 808	496	K	zuiveren van gras en onkruid	cleaning of grass and weeds	kadiehie	328	kadihi	k a d i h i	k a d i ç i						
 809	496	K	plat geslagen bamboe voor omwanding en vloer	flattened bamboo for wall and floor	kadiekopo	298	kadikopo	k a d i k o p o	k a d i k o p o						
-810	496	K	afval, vuil	waste, dirt	kadoboedoboe		kadobudobu	k a d o b u d o b u	k a d o b u d o b u						
-811	496	K	hitte, heet door vuur van water	heat, hot by fire from water	kadodohodie		kadodohodi	k a d o d o h o d i	k a d o d o h o d i						
+810	496	K	afval , vuil	waste , dirt	kadoboedoboe		kadobudobu	k a d o b u d o b u	k a d o b u d o b u						
+811	496	K	hitte , heet door vuur van water	heat , hot by fire from water	kadodohodie		kadodohodi	k a d o d o h o d i	k a d o d o h o d i						
 812	496	K	het moet nu uit zijn	it should be out now	kadoèhoeda		kaduhuda	k a d u h u d a	k a d u h u d a						
-813	496	K	beplanten van een veld, planten, begraven, in de aarde leggen	planting a field, planting, burying, putting in the earth	kadoqö		kado'u̇	k a d o ' u̇	k a d o ʔ ɨ						
-814	497	K	vervolgens, onmiddelijk, daarop	then, immediately, thereupon	kaènaha		kaEnaha	k a E n a h a	k a ɛ n a h a						
+813	496	K	beplanten van een veld , planten , begraven , in de aarde leggen	planting a field , planting , burying , putting in the earth	kadoqö		kado'u̇	k a d o ' u̇	k a d o ʔ ɨ						
+814	497	K	vervolgens , onmiddelijk , daarop	then , immediately , thereupon	kaènaha		kaEnaha	k a E n a h a	k a ɛ n a h a						
 815	497	K	staan	to stand	kaènoe		kaEnu	k a E n u	k a ɛ n u						
 816	497	K	kruipen van eene slang	crawling of a snake	kaèöèo		kaEu̇Eo	k a E u̇ E o	k a ɛ ɨ ɛ o						
-817	497	K	kom, komaan; (uitroep tot aansporing, opwekking)	come, come on; (exclamation of exhortation, exhortation)	kah		kah	k a h	k a h						
-818	497	K	loopen, gaan, op weg zijn, op weg gaan	walk, go, be on your way, be on your way	kaha		kaha	k a h a	k a h a						
+817	497	K	kom , komaan ; (uitroep tot aansporing , opwekking)	come , come on ; (exclamation of exhortation , exhortation)	kah		kah	k a h	k a h						
+818	497	K	loopen , gaan , op weg zijn , op weg gaan	walk , go , be on your way , be on your way	kaha		kaha	k a h a	k a h a						
 819	497	K	mededoen	join	kahabaja		kahabaya	k a h a b a y a	k a h a b a j a						
-820	497	K	eenig, alleen	single, only	kahabaoeba		kahabauba	k a h a b a u b a	k a h a b a u b a						
-821	497	K	werk, dat men heeft uit te voeren, arbeid; werken, arbeiden	work, which one has to perform, labour; working, labouring	kahabarieq		kahabari'	k a h a b a r i '	k a h a b a r i ʔ						
-822	497	K	vlaktemaat (bidang); hulptelwoord bij het opnoemen van bouwlanden	plains measure (bidang); auxiliary numeral when enumerating arable land	kahabieta		kahabita	k a h a b i t a	k a h a b i t a						
-823	497	K	ondeugend, kwaaddoende, stout	naughty, malicious, naughty	kahaè		kahaE	k a h a E	k a h a ɛ						
+820	497	K	eenig , alleen	single , only	kahabaoeba		kahabauba	k a h a b a u b a	k a h a b a u b a						
+821	497	K	werk , dat men heeft uit te voeren , arbeid ; werken , arbeiden	work , which one has to perform , labour ; working , labouring	kahabarieq		kahabari'	k a h a b a r i '	k a h a b a r i ʔ						
+822	497	K	vlaktemaat (bidang) ; hulptelwoord bij het opnoemen van bouwlanden	plains measure (bidang) ; auxiliary numeral when enumerating arable land	kahabieta		kahabita	k a h a b i t a	k a h a b i t a						
+823	497	K	ondeugend , kwaaddoende , stout	naughty , malicious , naughty	kahaè		kahaE	k a h a E	k a h a ɛ						
 824	497	K	overwal	bank/embankment on the other side of the water	kahapa	305	kahapa	k a h a p a	k a h a p a						
-825	497	K	bevreesd, bang, bang maken, vrees, vreezen	frightened, afraid, frighten, fear, dread	kahaho	314	kahaho	k a h a h o	k a h a h o						
+825	497	K	bevreesd , bang , bang maken , vrees , vreezen	frightened , afraid , frighten , fear , dread	kahaho	314	kahaho	k a h a h o	k a h a h o						
 826	497	K	iemand uitnoodigen bijv. om met hem mede te gaan	inviting someone e.g. to go with him	kahaie		kahai	k a h a i	k a h a i						
-827	497	K	gissen, meenen, denken, vermoeden	to guess, to think, to suspect	kahaiekoenaq		kahaikuna'	k a h a i k u n a '	k a h a i k u n a ʔ						
-828	497	K	nog, nog steeds, juist, zelfs, overig	still, still, right, even, other	kahaienoeapè	308	kahainuapE	k a h a i n u a p E	k a h a i n u a p ɛ						
-829	497	K	wenschen, willen, verlangen	wish, want, desire	kahaja		kahaya	k a h a y a	k a h a j a						
+827	497	K	gissen , meenen , denken , vermoeden	to guess , to think , to suspect	kahaiekoenaq		kahaikuna'	k a h a i k u n a '	k a h a i k u n a ʔ						
+828	497	K	nog , nog steeds , juist , zelfs , overig	still , still , right , even , other	kahaienoeapè	308	kahainuapE	k a h a i n u a p E	k a h a i n u a p ɛ						
+829	497	K	wenschen , willen , verlangen	wish , want , desire	kahaja		kahaya	k a h a y a	k a h a j a						
 830	497	K	snel van den stroom	fast current/flow	kahakakie		kahakaki	k a h a k a k i	k a h a k a k i						
-831	497	K	verdeelen, deelen	divide, share	kahakouda	309	kahakouda	k a h a k o u d a	k a h a k o u d a						
+831	497	K	verdeelen , deelen	divide , share	kahakouda	309	kahakouda	k a h a k o u d a	k a h a k o u d a						
 832	497	K			kahao		kahao	k a h a o	k a h a o						
-833	497	K	oom	uncle	kahao: èmanie	310	kahao: Emani	k a h a o : # E m a n i	k a h a o : # ɛ m a n i						
+833	497	K	oom	uncle	kahao:_èmanie	310	kahao:_Emani	k a h a o : _ E m a n i	k a h a o : _ ɛ m a n i						
 834	497	K	tante	aunt	èhöda		Ehu̇da	E h u̇ d a	ɛ h ɨ d a						
-835	497	K	bot, stomp	dull, blunt	kahaoeq		kahau'	k a h a u '	k a h a u ʔ						
-836	497	K	gebroken, doorgebroken, afgebroken	broken, broken through, broken off	kahaoka	311	kahaoka	k a h a o k a	k a h a o k a						
-837	497	K	over iets nadenken, overdenken, bedenken	thinking about something, pondering, imagining	kahapaq	306	kahapa'	k a h a p a '	k a h a p a ʔ						
-838	497	K	begeeren, verlangen, belust zijn op iets, willen ook van zaken; genoegen, vreugde, verheugd, tevreden zijn met iets, op iemand gesteld zijn; liefhebben, liefde	covet, desire, be anxious for something, want things too; pleasure, joy, delighted, be satisfied with something, be fond of someone; love, love	kahapie	307	kahapi	k a h a p i	k a h a p i						
-839	497	K	paar, koppel	pair, couple	kahapoeoeie(j)a		kahapu'ui(y)a	k a h a p u ' u i ( y ) a	k a h a p u ʔ u i ( j ) a						
+835	497	K	bot , stomp	dull , blunt	kahaoeq		kahau'	k a h a u '	k a h a u ʔ						
+836	497	K	gebroken , doorgebroken , afgebroken	broken , broken through , broken off	kahaoka	311	kahaoka	k a h a o k a	k a h a o k a						
+837	497	K	over iets nadenken , overdenken , bedenken	thinking about something , pondering , imagining	kahapaq	306	kahapa'	k a h a p a '	k a h a p a ʔ						
+838	497	K	begeeren , verlangen , belust zijn op iets , willen ook van zaken ; genoegen , vreugde , verheugd , tevreden zijn met iets , op iemand gesteld zijn ; liefhebben , liefde	covet , desire , be anxious for something , want things too ; pleasure , joy , delighted , be satisfied with something , be fond of someone ; love , love	kahapie	307	kahapi	k a h a p i	k a h a p i						
+839	497	K	paar , koppel	pair , couple	kahapoeoeie(j)a		kahapu'ui(y)a	k a h a p u ' u i ( y ) a	k a h a p u ʔ u i ( j ) a						
 840	497	K	opborrelen van het water uit een wel	bubbling up water from a well	kahapoeqoeie		kahapu'ui	k a h a p u ' u i	k a h a p u ʔ u i						
 841	497	K	één vaam	one fathom	kaharao		kaharao	k a h a r a o	k a h a r a o						
-842	497	K	onrein, onreinheid	unclean, impurity	kahèdohèdo	121	kahEdohEdo	k a h E d o h E d o	k a h ɛ d o h ɛ d o						
-843	497	K	plagen, sarren, tergen	tease, nag, taunt	kahèè		kahEE	k a h E E	k a h ɛ ɛ						
-844	497	K	krom, gebogen, bocht in eene rivier	crooked, curved, bend in a river	kahè(j)oq		kahE(y)o'	k a h E ( y ) o '	k a h ɛ ( j ) o ʔ						
-845	497	K	fijn, dun	fine, thin	kahiekanie		kahikani	k a h i k a n i	k a h i k a n i						
+842	497	K	onrein , onreinheid	unclean , impurity	kahèdohèdo	121	kahEdohEdo	k a h E d o h E d o	k a h ɛ d o h ɛ d o						
+843	497	K	plagen , sarren , tergen	tease , nag , taunt	kahèè		kahEE	k a h E E	k a h ɛ ɛ						
+844	497	K	krom , gebogen , bocht in eene rivier	crooked , curved , bend in a river	kahè(j)oq		kahE(y)o'	k a h E ( y ) o '	k a h ɛ ( j ) o ʔ						
+845	497	K	fijn , dun	fine , thin	kahiekanie		kahikani	k a h i k a n i	k a h i k a n i						
 846	497	K	witte mier	white ant	kahienoaq		kahinoa'	k a h i n o a '	k a h i n o a ʔ						
-847	497	K	steken, zeer doen	sting, hurt	kahiepa	312	kahipa	k a h i p a	k a h i p a						
-848	497	K	bovenloop eener rivier, eene rivier opvaren	upper reaches of a river, sailing up a river	kahoeie(j)oeroe(w)a		kahui(y)uru(w)a	k a h u i ( y ) u r u ( w ) a	k a h u i ( j ) u r u ( w ) a						
-849	497	K	opgezet van den buik, opgezwollen van de wangen	swollen belly, swollen cheeks	kahoepohoepoö	313	kahupohupo'o	k a h u p o h u p o ' o	k a h u p o h u p o ʔ o						
-850	498	K	stoel, spruit, stengel van planten	chair, shoot, stem of plants	kahopo		kahopo	k a h o p o	k a h o p o						
-851	498	K	ophouden, vertoeven, uitscheiden	cease, abide, excrete	kahö(w)a		kahu̇(w)a	k a h u̇ ( w ) a	k a h ɨ ( w ) a						
-852	498	K	met de armen aanvatten, vastgrijpen, pakken	seize, grasp, grab with the arms	kaie		kai	k a i	k a i						
-853	498	K	omlaag, naar beneden gaan	down, go down	kaie(j)aè		kai(y)aE	k a i ( y ) a E	k a i ( j ) a ɛ						
-854	498	K	stil zijn, zich stil houden, zwijgen, stil staan	be quiet, keep quiet, keep silent, stand still	kaie(j)anono	316	kai(y)anono	k a i ( y ) a n o n o	k a i ( j ) a n o n o						
+847	497	K	steken , zeer doen	sting , hurt	kahiepa	312	kahipa	k a h i p a	k a h i p a						
+848	497	K	bovenloop eener rivier , eene rivier opvaren	upper reaches of a river , sailing up a river	kahoeie(j)oeroe(w)a		kahui(y)uru(w)a	k a h u i ( y ) u r u ( w ) a	k a h u i ( j ) u r u ( w ) a						
+849	497	K	opgezet van den buik , opgezwollen van de wangen	swollen belly , swollen cheeks	kahoepohoepoö	313	kahupohupo'o	k a h u p o h u p o ' o	k a h u p o h u p o ʔ o						
+850	498	K	stoel , spruit , stengel van planten	chair , shoot , stem of plants	kahopo		kahopo	k a h o p o	k a h o p o						
+851	498	K	ophouden , vertoeven , uitscheiden	cease , abide , excrete	kahö(w)a		kahu̇(w)a	k a h u̇ ( w ) a	k a h ɨ ( w ) a						
+852	498	K	met de armen aanvatten , vastgrijpen , pakken	seize , grasp , grab with the arms	kaie		kai	k a i	k a i						
+853	498	K	omlaag , naar beneden gaan	down , go down	kaie(j)aè		kai(y)aE	k a i ( y ) a E	k a i ( j ) a ɛ						
+854	498	K	stil zijn , zich stil houden , zwijgen , stil staan	be quiet , keep quiet , keep silent , stand still	kaie(j)anono	316	kai(y)anono	k a i ( y ) a n o n o	k a i ( j ) a n o n o						
 855	498	K	in de lengte uitgestrekt	stretched lengthwise	kaie(j)ojo(q)		kai(y)oyo(')	k a i ( y ) o y o ( ' )	k a i ( j ) o j o ( ʔ )						
 856	498	K	rood	red	kaiekoko		kaikoko	k a i k o k o	k a i k o k o						
-857	498	K	smaak van iets, gevoel, geur	taste of something, feel, smell	kaienono(q)		kainono(')	k a i n o n o ( ' )	k a i n o n o ( ʔ )						
-858	498	K	ruim, wijd, open	spacious, wide, open	kajajaä		kayaya'a	k a y a y a ' a	k a j a j a ʔ a						
-859	498	K	recht, zonder bochten, oprecht	straight, without curves, sincere	kajo		kayo	k a y o	k a j o						
-860	498	K	op elkander volgen, gehoorzamen, volgen, meedoen	following one another, obeying, following, participating	kajoöie		kayo'oi	k a y o ' o i	k a j o ʔ o i						
+857	498	K	smaak van iets , gevoel , geur	taste of something , feel , smell	kaienono(q)		kainono(')	k a i n o n o ( ' )	k a i n o n o ( ʔ )						
+858	498	K	ruim , wijd , open	spacious , wide , open	kajajaä		kayaya'a	k a y a y a ' a	k a j a j a ʔ a						
+859	498	K	recht , zonder bochten , oprecht	straight , without curves , sincere	kajo		kayo	k a y o	k a j o						
+860	498	K	op elkander volgen , gehoorzamen , volgen , meedoen	following one another , obeying , following , participating	kajoöie		kayo'oi	k a y o ' o i	k a j o ʔ o i						
 861	498	K	uitgespannen zooals een touw	stretched like a rope	kakanaka	455	kakanaka	k a k a n a k a	k a k a n a k a						
-862	498	K	glans, luister	shine, listen	kakanakoe(w)a		kakanaku(w)a	k a k a n a k u ( w ) a	k a k a n a k u ( w ) a						
-863	498	K	een half, de helft	half, half	kakanèha		kakanEha	k a k a n E h a	k a k a n ɛ h a						
-864	498	K	drijven, voor zich uit drijven, wegjagen, nazetten, vervolgen, op iets afgaan, iemand of iets achternazetten, najagen	drive, drive ahead, chase away, pursue, pursue, go after something, chase someone or something, pursue	kakaraie		kakarai	k a k a r a i	k a k a r a i						
-865	498	K	woning, die de gedaante had van een op circa 10 hooge palen geplaatsten , bijenkorf (zulke woningen worden niet meer gebouwd)	house, which had the shape of a beehive placed on about 10 high poles (such houses are no longer built)	kakarie(j)o		kakari(y)o	k a k a r i ( y ) o	k a k a r i ( j ) o						
-866	498	K	strak, stijf aangehaald	tightly, rigidly tightened	kakèkaka		kakEkaka	k a k E k a k a	k a k ɛ k a k a						
-867	498	K	stoel, spruit, stengel van planten	chair, shoot, stem of plants	kakèlèha		kakElEha	k a k E l E h a	k a k ɛ l ɛ h a						
+862	498	K	glans , luister	shine , listen	kakanakoe(w)a		kakanaku(w)a	k a k a n a k u ( w ) a	k a k a n a k u ( w ) a						
+863	498	K	een half , de helft	half , half	kakanèha		kakanEha	k a k a n E h a	k a k a n ɛ h a						
+864	498	K	drijven , voor zich uit drijven , wegjagen , nazetten , vervolgen , op iets afgaan , iemand of iets achternazetten , najagen	drive , drive ahead , chase away , pursue , pursue , go after something , chase someone or something , pursue	kakaraie		kakarai	k a k a r a i	k a k a r a i						
+865	498	K	woning , die de gedaante had van een op circa 10 hooge palen geplaatsten , bijenkorf (zulke woningen worden niet meer gebouwd)	house , which had the shape of a beehive placed on about 10 high poles (such houses are no longer built)	kakarie(j)o		kakari(y)o	k a k a r i ( y ) o	k a k a r i ( j ) o						
+866	498	K	strak , stijf aangehaald	tightly , rigidly tightened	kakèkaka		kakEkaka	k a k E k a k a	k a k ɛ k a k a						
+867	498	K	stoel , spruit , stengel van planten	chair , shoot , stem of plants	kakèlèha		kakElEha	k a k E l E h a	k a k ɛ l ɛ h a						
 868	498	K	geel	yellow	kakiedahaie(j)o		kakidahai(y)o	k a k i d a h a i ( y ) o	k a k i d a h a i ( j ) o						
 869	498	K	sterk verlangen naar iemand of iets	strong desire for someone or something	kakiedjoa		kakijoa	k a k i j o a	k a k i d͡ʒ o a						
-870	498	K	voorbij, gepasseerd, voorbijgaan, passeeren	passed, passed, pass, pass by	kakiedohè		kakidohE	k a k i d o h E	k a k i d o h ɛ						
-871	498	K	recht toe, recht aan	straightforward	kakiekiedohè		kakikidohE	k a k i k i d o h E	k a k i k i d o h ɛ						
-872	498	K	verborgen, verscholen	hidden, tucked away	kakiekie(j)oe		kakiki(y)u	k a k i k i ( y ) u	k a k i k i ( j ) u						
-873	498	K	spat, spikkel, vlekje	splash, speck, spot	kakiepakiepa		kakipakipa	k a k i p a k i p a	k a k i p a k i p a						
+870	498	K	voorbij , gepasseerd , voorbijgaan , passeeren	passed , passed , pass , pass by	kakiedohè		kakidohE	k a k i d o h E	k a k i d o h ɛ						
+871	498	K	recht toe , recht aan	straightforward	kakiekiedohè		kakikidohE	k a k i k i d o h E	k a k i k i d o h ɛ						
+872	498	K	verborgen , verscholen	hidden , tucked away	kakiekie(j)oe		kakiki(y)u	k a k i k i ( y ) u	k a k i k i ( j ) u						
+873	498	K	spat , spikkel , vlekje	splash , speck , spot	kakiepakiepa		kakipakipa	k a k i p a k i p a	k a k i p a k i p a						
 874	498	K	dalen van hemellichamen	descending of celestial bodies	kakoehè		kakuhE	k a k u h E	k a k u h ɛ						
-875	498	K	curcuma (het mal. koenjit?); geel	curcuma (the Malay turmeric?); yellow	kakoenjè		kakuñE	k a k u ñ E	k a k u ɲ ɛ						
-876	498	K	laag, nederig	low, humble	kakoeöqö		kaku'o'u̇	k a k u ' o ' u̇	k a k u ʔ o ʔ ɨ						
-877	498	K	geknakt, afgebroken, breken, afbreken, in stukken breken	snapped, broken off, breaking, breaking into pieces	kaköoe		kaku̇u	k a k u̇ u	k a k ɨ u						
+875	498	K	curcuma (het mal. koenjit ? ) ; geel	curcuma (the Malay turmeric ? ) ; yellow	kakoenjè		kakuñE	k a k u ñ E	k a k u ɲ ɛ						
+876	498	K	laag , nederig	low , humble	kakoeöqö		kaku'o'u̇	k a k u ' o ' u̇	k a k u ʔ o ʔ ɨ						
+877	498	K	geknakt , afgebroken , breken , afbreken , in stukken breken	snapped , broken off , breaking , breaking into pieces	kaköoe		kaku̇u	k a k u̇ u	k a k ɨ u						
 878	498	K	iets aan de geesten afsmeeken	implore something from the spirits	kakoro(w)a		kakoro(w)a	k a k o r o ( w ) a	k a k o r o ( w ) a						
 879	498	K	feest	party	kalèaq		kalEa'	k a l E a '	k a l ɛ a ʔ						
 880	498	K	het groote feest	the great feast	kalèaq(oe)baba		kalEa'(u)baba	k a l E a ' ( u ) b a b a	k a l ɛ a ʔ ( u ) b a b a						
 881	498	K	overkomen van ongelukken	have accidents happen	kamanaä		kamana'a	k a m a n a ' a	k a m a n a ʔ a						
-882	498	K	niet willen, niet verlangen	not wanting, not desiring	kamoepie	319	kamupi	k a m u p i	k a m u p i						
-883	498	K	iets wat pas uitstoelt, wat pas opkomt van aanplantingen	something that recently came out, that recently emerged from plantings	kamoenieno		kamunino	k a m u n i n o	k a m u n i n o						
-884	498	K	het mal.: «maka»	the Malay: “maka”	kamoho		kamoho	k a m o h o	k a m o h o						
-885	498	K	zoet, lief, innemend	sweet, sweet, engaging	kamonie		kamoni	k a m o n i	k a m o n i						
+882	498	K	niet willen , niet verlangen	not wanting , not desiring	kamoepie	319	kamupi	k a m u p i	k a m u p i						
+883	498	K	iets wat pas uitstoelt , wat pas opkomt van aanplantingen	something that recently came out , that recently emerged from plantings	kamoenieno		kamunino	k a m u n i n o	k a m u n i n o						
+884	498	K	het mal. : «maka»	the Malay : “maka”	kamoho		kamoho	k a m o h o	k a m o h o						
+885	498	K	zoet , lief , innemend	sweet , sweet , engaging	kamonie		kamoni	k a m o n i	k a m o n i						
 886	499	K	een van de typen van eene Engganeesche lans	one of the types of an Engganese lance	kanakienie		kanakini	k a n a k i n i	k a n a k i n i						
-887	499	K	oud mannetje; oud vrouwtje	old male; old female	kanapoe		kanapu	k a n a p u	k a n a p u						
-888	499	K	druipen, lekken, een druppel, een lek	drip, leak, a drip, a leak	kanapoeäq		kanapu'a'	k a n a p u ' a '	k a n a p u ʔ a ʔ						
-889	499	K	schimmel, beschimmeld	mould, mildewed	kanapoenoe		kanapunu	k a n a p u n u	k a n a p u n u						
-890	499	K	er door kunnen, ruim genoeg om iets door te laten, te laten doorgaan	be able to get through, spacious enough to let something through, pass	kanèko	412	kanEko	k a n E k o	k a n ɛ k o						
-891	499	K	dun, fijn, teer	thin, fine, delicate	kanènè		kanEnE	k a n E n E	k a n ɛ n ɛ						
-892	499	K	glad, glibberig	smooth, slippery	kanènonèno		kanEnonEno	k a n E n o n E n o	k a n ɛ n o n ɛ n o						
-893	499	K	opgelost, verteerd	dissolved, digested	kanèonèo		kanEonEo	k a n E o n E o	k a n ɛ o n ɛ o						
-894	499	K	kort, niet lang	short, not long	kanèpoe	320	kanEpu	k a n E p u	k a n ɛ p u						
-895	499	K	beschaamd, verlegen	embarrassed, shy	kanè(q)a		kanE(')a	k a n E ( ' ) a	k a n ɛ ( ʔ ) a						
+887	499	K	oud mannetje ; oud vrouwtje	old male ; old female	kanapoe		kanapu	k a n a p u	k a n a p u						
+888	499	K	druipen , lekken , een druppel , een lek	drip , leak , a drip , a leak	kanapoeäq		kanapu'a'	k a n a p u ' a '	k a n a p u ʔ a ʔ						
+889	499	K	schimmel , beschimmeld	mould , mildewed	kanapoenoe		kanapunu	k a n a p u n u	k a n a p u n u						
+890	499	K	er door kunnen , ruim genoeg om iets door te laten , te laten doorgaan	be able to get through , spacious enough to let something through , pass	kanèko	412	kanEko	k a n E k o	k a n ɛ k o						
+891	499	K	dun , fijn , teer	thin , fine , delicate	kanènè		kanEnE	k a n E n E	k a n ɛ n ɛ						
+892	499	K	glad , glibberig	smooth , slippery	kanènonèno		kanEnonEno	k a n E n o n E n o	k a n ɛ n o n ɛ n o						
+893	499	K	opgelost , verteerd	dissolved , digested	kanèonèo		kanEonEo	k a n E o n E o	k a n ɛ o n ɛ o						
+894	499	K	kort , niet lang	short , not long	kanèpoe	320	kanEpu	k a n E p u	k a n ɛ p u						
+895	499	K	beschaamd , verlegen	embarrassed , shy	kanè(q)a		kanE(')a	k a n E ( ' ) a	k a n ɛ ( ʔ ) a						
 896	499	K	vlug in bewegingen	swift in movements	kaniehie	321	kanihi	k a n i h i	k a n i ç i						
-897	499	K	licht, helder, duidelijk, doorschijnend	light, clear, translucent	kaniekie		kaniki	k a n i k i	k a n i k i						
-898	499	K	lek, lekken inz. van eene woning	leak, leakage of a property	kaniekoä(a)q		kaniko'a(a)'	k a n i k o ' a ( a ) '	k a n i k o ʔ a ( a ) ʔ						
+897	499	K	licht , helder , duidelijk , doorschijnend	light , clear , translucent	kaniekie		kaniki	k a n i k i	k a n i k i						
+898	499	K	lek , lekken inz. van eene woning	leak , leakage of a property	kaniekoä(a)q		kaniko'a(a)'	k a n i k o ' a ( a ) '	k a n i k o ʔ a ( a ) ʔ						
 899	499	K	hevig kloppen van het hart	heavy beating of the heart	kanie(nie)kie		kani(ni)ki	k a n i ( n i ) k i	k a n i ( n i ) k i						
-900	499	K	niet fijn genoeg, niet dun genoeg	not fine enough, not thin enough	kanieniepo(w)a		kaninipo(w)a	k a n i n i p o ( w ) a	k a n i n i p o ( w ) a						
-901	499	K	ongeluk, onheil	accident, calamity	kanoeaie		kanuai	k a n u a i	k a n u a i						
-902	499	K	dik, niet vloeibaar	thick, not liquid	kanoeanoea		kanuanua	k a n u a n u a	k a n u a n u a						
-903	499	K	schaduw, schaduwbeeld	shadow, shadow image	kanoeqkoe(w)aie		kanu'ku(w)ai	k a n u ' k u ( w ) a i	k a n u ʔ k u ( w ) a i						
+900	499	K	niet fijn genoeg , niet dun genoeg	not fine enough , not thin enough	kanieniepo(w)a		kaninipo(w)a	k a n i n i p o ( w ) a	k a n i n i p o ( w ) a						
+901	499	K	ongeluk , onheil	accident , calamity	kanoeaie		kanuai	k a n u a i	k a n u a i						
+902	499	K	dik , niet vloeibaar	thick , not liquid	kanoeanoea		kanuanua	k a n u a n u a	k a n u a n u a						
+903	499	K	schaduw , schaduwbeeld	shadow , shadow image	kanoeqkoe(w)aie		kanu'ku(w)ai	k a n u ' k u ( w ) a i	k a n u ʔ k u ( w ) a i						
 904	499	K	iets (bijv. regenwater) opvangen door er wat onder te houden	collect something (e.g. rainwater) by holding something under it	kanoöho(w)aq		kano'oho(w)a'	k a n o ' o h o ( w ) a '	k a n o ʔ o h o ( w ) a ʔ						
-905	499	K	opgesloten, ingesloten	trapped, enclosed	kao(e)		kao(e)	k a o ( e )	k a o ( e )						
-906	499	K	dat, waar men op drijft	that, on which one floats / that, which one aims at	kaoeäq		kau'a'	k a u ' a '	k a u ʔ a ʔ						
+905	499	K	opgesloten , ingesloten	trapped , enclosed	kao(e)		kao(e)	k a o ( e )	k a o ( e )						
+906	499	K	dat , waar men op drijft	that , on which one floats / that , which one aims at	kaoeäq		kau'a'	k a u ' a '	k a u ʔ a ʔ						
 907	499	K	doesoen	hamlet	kaoedada	324	kaudada	k a u d a d a	k a u d a d a						
-908	499	K	wit, blank, zuiver	white, clear, pure	kaoedahjo	326	kaudahyo	k a u d a h y o	k a u d a h j o						
+908	499	K	wit , blank , zuiver	white , clear , pure	kaoedahjo	326	kaudahyo	k a u d a h y o	k a u d a h j o						
 909	499	K	naakt	nude	kaoedaoe(w)arah		kaudau(w)arah	k a u d a u ( w ) a r a h	k a u d a u ( w ) a r a h						
-910	499	K	het ophouden, omhooghouden om iets op te vangen	holding up, holding up to catch something	kaoedèqää		kaudE'a'a	k a u d E ' a ' a	k a u d ɛ ʔ a ʔ a						
+910	499	K	het ophouden , omhooghouden om iets op te vangen	holding up , holding up to catch something	kaoedèqää		kaudE'a'a	k a u d E ' a ' a	k a u d ɛ ʔ a ʔ a						
 911	499	K	plein van eene doesoen	square of a doesoen	kaoenie(j)a		kauni(y)a	k a u n i ( y ) a	k a u n i ( j ) a						
-912	499	K	nog niet, nog nooit	not yet, never yet	kaoepè(q)	325	kaupE(')	k a u p E ( ' )	k a u p ɛ ( ʔ )						
-913	499	K	mooi, fraai, goed; aangenaam voor de zintuigen inz. lekker om te eten V.g.l.: èkaoe(w)a	beautiful, handsome, good; pleasing to the senses e.g., nice to eat; cf. : “èkaoe(w)a”	kaoe(w)a	323	kau(w)a	k a u ( w ) a	k a u ( w ) a	èkaoe(w)a	Ekau(w)a	E k a u ( w ) a	399	ɛ k a u ( w ) a	
-914	499	K	zout, brak	saline, brackish	kaoe(w)èoe(w)è		kau(w)Eu(w)E	k a u ( w ) E u ( w ) E	k a u ( w ) ɛ u ( w ) ɛ						
+912	499	K	nog niet , nog nooit	not yet , never yet	kaoepè(q)	325	kaupE(')	k a u p E ( ' )	k a u p ɛ ( ʔ )						
+913	499	K	mooi , fraai , goed ; aangenaam voor de zintuigen inz. lekker om te eten V.g.l. : èkaoe(w)a	beautiful , handsome , good ; pleasing to the senses e.g. , nice to eat ; cf. : “èkaoe(w)a”	kaoe(w)a	323	kau(w)a	k a u ( w ) a	k a u ( w ) a	èkaoe(w)a	Ekau(w)a	E k a u ( w ) a	399	ɛ k a u ( w ) a	
+914	499	K	zout , brak	saline , brackish	kaoe(w)èoe(w)è		kau(w)Eu(w)E	k a u ( w ) E u ( w ) E	k a u ( w ) ɛ u ( w ) ɛ						
 915	499	K	zwart	black	kaoe(w)ie		kau(w)i	k a u ( w ) i	k a u ( w ) i						
-916	499	K	ebbe, vallen van het water	ebb, falling of the water	kaokie		kaoki	k a o k i	k a o k i						
-917	499	K	raak zijn, geraakt	hit, hit	kaoöbo	292	kao'obo	k a o ' o b o	k a o ʔ o b o						
-918	499	K	onbeschoft, ruw, ongemanierd	rude, rough, ill-mannered	kaoöèiedjie	327	kao'oEiji	k a o ' o E i j i	k a o ʔ o ɛ i d͡ʒ i						
-919	499	K	hard, stijf, taai, onbuigzaam	hard, rigid, tough, inflexible	kaoöo		kao'oo	k a o ' o o	k a o ʔ o o						
-920	499	K	geschild, gepeld, gevild	peeled, skinned	kapaie		kapai	k a p a i	k a p a i						DI. 71. 33
-921	500	K	(mal.), groot schip, vaartuig	(Malay), large ship, vessel	kapal	300	kapal	k a p a l	k a p a l						malay
-922	500	K	(mal.); stoomschip	(Malay), steamship	kapal api	301	kapal api	k a p a l # a p i	k a p a l # a p i						malay
-923	500	K	de overzijde van eene rivier, oversteken	the other side of a river, crossing	kapaoe		kapau	k a p a u	k a p a u						
-924	500	K	zeldzaam, schaarsch, wijd van elkander	rare, scarce, widely separated	kapĕrapĕraba	302	kapėrapėraba	k a p ė r a p ė r a b a	k a p ə r a p ə r a b a						
-925	500	K	misleiding, dwaling, verkeerd zijn, mis, verdwaald, dwalen	deception, error, being wrong, wrong, lost, erring	kapieho		kapiho	k a p i h o	k a p i ç o						
-926	500	K	midden, middelmatig	medium, average/mediocre (?)	kapoe		kapu	k a p u	k a p u						
-927	500	K			kapoeho		kapuho	k a p u h o	k a p u h o	èdaboeho	Edabuho	E d a b u h o	230 ; 231	ɛ d a b u h o	
+916	499	K	ebbe , vallen van het water	ebb , falling of the water	kaokie		kaoki	k a o k i	k a o k i						
+917	499	K	raak zijn , geraakt	hit , hit	kaoöbo	292	kao'obo	k a o ' o b o	k a o ʔ o b o						
+918	499	K	onbeschoft , ruw , ongemanierd	rude , rough , ill-mannered	kaoöèiedjie	327	kao'oEiji	k a o ' o E i j i	k a o ʔ o ɛ i d͡ʒ i						
+919	499	K	hard , stijf , taai , onbuigzaam	hard , rigid , tough , inflexible	kaoöo		kao'oo	k a o ' o o	k a o ʔ o o						
+920	499	K	geschild , gepeld , gevild	peeled , skinned	kapaie		kapai	k a p a i	k a p a i						DI. 71. 33
+921	500	K	(mal.) , groot schip , vaartuig	(Malay) , large ship , vessel	kapal	300	kapal	k a p a l	k a p a l						malay
+922	500	K	(mal.) ; stoomschip	(Malay) , steamship	kapal_api	301	kapal_api	k a p a l _ a p i	k a p a l _ a p i						malay
+923	500	K	de overzijde van eene rivier , oversteken	the other side of a river , crossing	kapaoe		kapau	k a p a u	k a p a u						
+924	500	K	zeldzaam , schaarsch , wijd van elkander	rare , scarce , widely separated	kapĕrapĕraba	302	kapėrapėraba	k a p ė r a p ė r a b a	k a p ə r a p ə r a b a						
+925	500	K	misleiding , dwaling , verkeerd zijn , mis , verdwaald , dwalen	deception , error , being wrong , wrong , lost , erring	kapieho		kapiho	k a p i h o	k a p i ç o						
+926	500	K	midden , middelmatig	medium , average/mediocre ( ? )	kapoe		kapu	k a p u	k a p u						
+927	500	K			kapoeho		kapuho	k a p u h o	k a p u h o	èdaboeho	Edabuho	E d a b u h o	230	ɛ d a b u h o	
+927	500	K			kapoeho		kapuho	k a p u h o	k a p u h o	èdaboeho	Edabuho	E d a b u h o	231	ɛ d a b u h o	
 928	500	K	onbegaanbaar	impassable	kapoeka	303	kapuka	k a p u k a	k a p u k a						
-929	500	K	instorten van woningen, van rotsen, ineenzakken inz. aan den kant	collapse of dwellings, of rocks, collapse, e.g., on the side	kapoeq(oe)a		kapu'(u)a	k a p u ' ( u ) a	k a p u ʔ ( u ) a						
+929	500	K	instorten van woningen , van rotsen , ineenzakken inz. aan den kant	collapse of dwellings , of rocks , collapse , e.g. , on the side	kapoeq(oe)a		kapu'(u)a	k a p u ' ( u ) a	k a p u ʔ ( u ) a						
 930	500	K	lekslaan van een vaartuig	leakage of a vessel	kapoko		kapoko	k a p o k o	k a p o k o						
-931	500	K	betrokken van de lucht, donker, duister van den nacht, de zon, de maan	cloudy (for the sky), dark, darkness of the night, the sun, the moon	kapopo	304	kapopo	k a p o p o	k a p o p o						
-932	500	K	betrokken van de lucht, donker, duister van den nacht, de zon, de maan	cloudy (for the sky), dark, darkness of the night, the sun, the moon	kĕpopo	337	kėpopo	k ė p o p o	k ə p o p o						
+931	500	K	betrokken van de lucht , donker , duister van den nacht , de zon , de maan	cloudy (for the sky) , dark , darkness of the night , the sun , the moon	kapopo	304	kapopo	k a p o p o	k a p o p o						
+932	500	K	betrokken van de lucht , donker , duister van den nacht , de zon , de maan	cloudy (for the sky) , dark , darkness of the night , the sun , the moon	kĕpopo	337	kėpopo	k ė p o p o	k ə p o p o						
 933	500	K	roest	rust	kaqakaie		ka'akai	k a ' a k a i	k a ʔ a k a i						
-934	500	K	aangenaam van geur, reuk, lucht	pleasant smell, air	kaqamano		ka'amano	k a ' a m a n o	k a ʔ a m a n o						
+934	500	K	aangenaam van geur , reuk , lucht	pleasant smell , air	kaqamano		ka'amano	k a ' a m a n o	k a ʔ a m a n o						
 935	500	K	ongelijk hebben	being wrong	kaqapopoero		ka'apopuro	k a ' a p o p u r o	k a ʔ a p o p u r o						
-936	500	K	achterdocht, achterdochtig	suspicion, suspicious	kaqienèaoe		ka'inEau	k a ' i n E a u	k a ʔ i n ɛ a u						
-937	500	K	sluiten, dekken, toemaken	close, cover, close off	karaoe		karau	k a r a u	k a r a u						
+936	500	K	achterdocht , achterdochtig	suspicion , suspicious	kaqienèaoe		ka'inEau	k a ' i n E a u	k a ʔ i n ɛ a u						
+937	500	K	sluiten , dekken , toemaken	close , cover , close off	karaoe		karau	k a r a u	k a r a u						
 938	500	K	troebel	cloudy	karieporiepo	318	kariporipo	k a r i p o r i p o	k a r i p o r i p o						
 939	500	K	broek	trousers	karoe(oe)(w)a		karu(u)(w)a	k a r u ( u ) ( w ) a	k a r u ( u ) ( w ) a						
-940	500	K	bedekt, achter iets verborgen	covered, hidden behind something	karohaja	329	karohaya	k a r o h a y a	k a r o h a j a						
-941	500	K	landschap, district	landscape, district	karorie(j)ĕ		karori(y)ė	k a r o r i ( y ) ė	k a r o r i ( j ) ə						
+940	500	K	bedekt , achter iets verborgen	covered , hidden behind something	karohaja	329	karohaya	k a r o h a y a	k a r o h a j a						
+941	500	K	landschap , district	landscape , district	karorie(j)ĕ		karori(y)ė	k a r o r i ( y ) ė	k a r o r i ( j ) ə						
 942	500	K	komen	come	kĕbahè		kėbahE	k ė b a h E	k ə b a h ɛ						
-943	500	K	(mal.), gordijn	(Mal.), curtain	kĕlamboe		kėlambu	k ė l a m b u	k ə l a m b u						malay
+943	500	K	(mal.) , gordijn	(Mal.) , curtain	kĕlamboe		kėlambu	k ė l a m b u	k ə l a m b u						malay
 944	500	K	tritonschelp als omroepershoorn gebezigd	triton shell used as announcer's horn	kĕmie(j)oe		kėmi(y)u	k ė m i ( y ) u	k ə m i ( j ) u						
-945	500	K	op, niet meer voorhanden	finished, no longer available	kĕnaja		kėnaya	k ė n a y a	k ə n a j a	èkanaja	Ekanaya	E k a n a y a	393	ɛ k a n a j a	v.g.l.: èkanaja
-946	500	K	(mal.), ijzeren pan	(Mal.), iron pan	kĕwalie		kėwali	k ė w a l i	k ə w a l i						malay
-947	500	K	maar, doch, evenwel, echter	but, but, though, however	kè		kE	k E	k ɛ						
-948	500	K	voorbijgaan, doorgaan zonder er op te letten	passing by, continuing without paying attention to it	kèè		kEE	k E E	k ɛ ɛ						
-949	500	K	gebroken van voorwerpen, zooals beenderen, stokken, armen, beenen	broken of objects, such as bones, sticks, arms, legs	kèhèkoq		kEhEko'	k E h E k o '	k ɛ h ɛ k o ʔ						
-950	500	K	mager, smal, tenger	skinny, slim, petite	kèhèla		kEhEla	k E h E l a	k ɛ h ɛ l a						
+945	500	K	op , niet meer voorhanden	finished , no longer available	kĕnaja		kėnaya	k ė n a y a	k ə n a j a	èkanaja	Ekanaya	E k a n a y a	393	ɛ k a n a j a	v.g.l.: èkanaja
+946	500	K	(mal.) , ijzeren pan	(Mal.) , iron pan	kĕwalie		kėwali	k ė w a l i	k ə w a l i						malay
+947	500	K	maar , doch , evenwel , echter	but , but , though , however	kè		kE	k E	k ɛ						
+948	500	K	voorbijgaan , doorgaan zonder er op te letten	passing by , continuing without paying attention to it	kèè		kEE	k E E	k ɛ ɛ						
+949	500	K	gebroken van voorwerpen , zooals beenderen , stokken , armen , beenen	broken of objects , such as bones , sticks , arms , legs	kèhèkoq		kEhEko'	k E h E k o '	k ɛ h ɛ k o ʔ						
+950	500	K	mager , smal , tenger	skinny , slim , petite	kèhèla		kEhEla	k E h E l a	k ɛ h ɛ l a						
 951	500	K	oorlel	earlobe	kèho		kEho	k E h o	k ɛ h o						
-952	500	K	iets, waarmede men iets uitpeutert, iets uithaalt	something, with which one pokes something out, extracts something	kèhodojo	335	kEhodoyo	k E h o d o y o	k ɛ h o d o j o						
+952	500	K	iets , waarmede men iets uitpeutert , iets uithaalt	something , with which one pokes something out , extracts something	kèhodojo	335	kEhodoyo	k E h o d o y o	k ɛ h o d o j o						
 953	500	K	te vergeefs	in vain	kèhowa		kEhowa	k E h o w a	k ɛ h o w a						
-954	500	K	stompen, vuistslagen geven	punching, giving fist/throwing punch	kèkèqie		kEkE'i	k E k E ' i	k ɛ k ɛ ʔ i						
-955	500	K	niet tot stand komen, niet ontstaan, niet gebeuren	not coming into being, not arising, not happening	kèkoe(w)èq		kEku(w)E'	k E k u ( w ) E '	k ɛ k u ( w ) ɛ ʔ						
-956	501	K	modder, slib, slik	mud, silt, sludge	kèlokèlo		kElokElo	k E l o k E l o	k ɛ l o k ɛ l o						
-957	501	K	tellen, rekenen	counting, arithmetic	kèma		kEma	k E m a	k ɛ m a						
-958	501	K	houwen, hakken, doorhakken	hack, chop, slash	kèmonaq		kEmona'	k E m o n a '	k ɛ m o n a ʔ						
-959	501	K	niet bestaan, niet aanwezig zijn	not exist, not be present	kèo		kEo	k E o	k ɛ o						
+954	500	K	stompen , vuistslagen geven	punching , giving fist/throwing punch	kèkèqie		kEkE'i	k E k E ' i	k ɛ k ɛ ʔ i						
+955	500	K	niet tot stand komen , niet ontstaan , niet gebeuren	not coming into being , not arising , not happening	kèkoe(w)èq		kEku(w)E'	k E k u ( w ) E '	k ɛ k u ( w ) ɛ ʔ						
+956	501	K	modder , slib , slik	mud , silt , sludge	kèlokèlo		kElokElo	k E l o k E l o	k ɛ l o k ɛ l o						
+957	501	K	tellen , rekenen	counting , arithmetic	kèma		kEma	k E m a	k ɛ m a						
+958	501	K	houwen , hakken , doorhakken	hack , chop , slash	kèmonaq		kEmona'	k E m o n a '	k ɛ m o n a ʔ						
+959	501	K	niet bestaan , niet aanwezig zijn	not exist , not be present	kèo		kEo	k E o	k ɛ o						
 960	501	K	voorvoegsel tot vorming van het passief	prefix to form the passive	kie		ki	k i	k i						
-961	501	K	een flap, een klap	a flap, a slap	kiea		kia	k i a	k i a	kieqja	ki'ya	k i ' y a	1116	k i ʔ j a	v.g.l.: kieqja
-962	501	K	kip, hoen	chicken, fowl	kieadoboe	8	kiadobu	k i a d o b u	k i a d o b u						
-963	501	K	bodem, vaste wal	bottom, mainland	kieakie		kiaki	k i a k i	k i a k i						
-964	501	K	stok met twee of drie ijzeren punten, waarmede de visschen, die uit het net trachten te ontsnappen, worden gestoken	stick with two or three iron points, with which the fish trying to escape from the net are stabbed	kieakoena		kiakuna	k i a k u n a	k i a k u n a						
+961	501	K	een flap , een klap	a flap , a slap	kiea		kia	k i a	k i a	kieqja	ki'ya	k i ' y a	1116	k i ʔ j a	v.g.l.: kieqja
+962	501	K	kip , hoen	chicken , fowl	kieadoboe	8	kiadobu	k i a d o b u	k i a d o b u						
+963	501	K	bodem , vaste wal	bottom , mainland	kieakie		kiaki	k i a k i	k i a k i						
+964	501	K	stok met twee of drie ijzeren punten , waarmede de visschen , die uit het net trachten te ontsnappen , worden gestoken	stick with two or three iron points , with which the fish trying to escape from the net are stabbed	kieakoena		kiakuna	k i a k u n a	k i a k u n a						
 965	501	K	een van de typen van een Engganeesche lans.	one of the types of an Engganese lance	kieakoeq		kiaku'	k i a k u '	k i a k u ʔ						
-966	501	K	vast tegen iets aanzitten, aankleven, vast blijven zitten	stuck to something, stuck to something, stuck to something	kieapaä		kiapa'a	k i a p a ' a	k i a p a ʔ a						
-967	501	K	onrijp, jong	unripe, young	kiebaka		kibaka	k i b a k a	k i b a k a						
-968	501	K	verwelkt, verdord	withered, withered	kiebèdieka	340	kibEdika	k i b E d i k a	k i b ɛ d i k a						
+966	501	K	vast tegen iets aanzitten , aankleven , vast blijven zitten	stuck to something , stuck to something , stuck to something	kieapaä		kiapa'a	k i a p a ' a	k i a p a ʔ a						
+967	501	K	onrijp , jong	unripe , young	kiebaka		kibaka	k i b a k a	k i b a k a						
+968	501	K	verwelkt , verdord	withered , withered	kiebèdieka	340	kibEdika	k i b E d i k a	k i b ɛ d i k a						
 969	501	K	jong	young	kieboeho		kibuho	k i b u h o	k i b u h o						
-970	501	K	wild, niet tam of mak	wild, not tame	kiebohèie		kibohEi	k i b o h E i	k i b o h ɛ i						
-971	501	K	een stuk, een afgesneden stuk	a piece, a cut-off piece	kiedahoho	390	kidahoho	k i d a h o h o	k i d a h o h o						
-972	501	K	het met iets fijns of puntigs in of door iets steken, iets puntigs om mede te steken	stabbing into or through something with something fine or pointed, something pointed to stab along	kiedahaq	389	kidaha'	k i d a h a '	k i d a h a ʔ						
+970	501	K	wild , niet tam of mak	wild , not tame	kiebohèie		kibohEi	k i b o h E i	k i b o h ɛ i						
+971	501	K	een stuk , een afgesneden stuk	a piece , a cut-off piece	kiedahoho	390	kidahoho	k i d a h o h o	k i d a h o h o						
+972	501	K	het met iets fijns of puntigs in of door iets steken , iets puntigs om mede te steken	stabbing into or through something with something fine or pointed , something pointed to stab along	kiedahaq	389	kidaha'	k i d a h a '	k i d a h a ʔ						
 973	501	K	rouwtijd	mourning period	kiedahoaq		kidahoa'	k i d a h o a '	k i d a h o a ʔ						
-974	501	K	hellend, scheef	sloping, oblique	kiedajaq		kidaya'	k i d a y a '	k i d a j a ʔ						
-975	501	K	plat van een bord	flat, of a plate	kiedaoedaoe		kidaudau	k i d a u d a u	k i d a u d a u						
-976	501	K	alle, geheel en al	all, entirely	kiedara		kidara	k i d a r a	k i d a r a						
+974	501	K	hellend , scheef	sloping , oblique	kiedajaq		kidaya'	k i d a y a '	k i d a j a ʔ						
+975	501	K	plat van een bord	flat , of a plate	kiedaoedaoe		kidaudau	k i d a u d a u	k i d a u d a u						
+976	501	K	alle , geheel en al	all , entirely	kiedara		kidara	k i d a r a	k i d a r a						
 977	501	K	koper	copper	kiedèdè(j)aq	387	kidEdE(y)a'	k i d E d E ( y ) a '	k i d ɛ d ɛ ( j ) a ʔ						
 978	501	K	doorboren	pierce	kiedie		kidi	k i d i	k i d i						
-979	501	K	doorboren van de oorlel	piercing the earlobe	kiedie (è)kèho		kidi (E)kEho	k i d i # ( E ) k E h o	k i d i # ( ɛ ) k ɛ h o						
-980	501	K	ruim, wijd, open	spacious, wide, open	kiediediehoq		kididiho'	k i d i d i h o '	k i d i d i ç o ʔ						
-981	501	K	vlijtig, naarstig	diligently, diligently	kiediedieka		kididika	k i d i d i k a	k i d i d i k a						
+979	501	K	doorboren van de oorlel	piercing the earlobe	kiedie_(è)kèho		kidi_(E)kEho	k i d i _ ( E ) k E h o	k i d i _ ( ɛ ) k ɛ h o						
+980	501	K	ruim , wijd , open	spacious , wide , open	kiediediehoq		kididiho'	k i d i d i h o '	k i d i d i ç o ʔ						
+981	501	K	vlijtig , naarstig	diligently , diligently	kiediedieka		kididika	k i d i d i k a	k i d i d i k a						
 982	501	K	woning	house	kiedieopè		kidiopE	k i d i o p E	k i d i o p ɛ						
 983	501	K	wegwerpen	discard	kiediepoe		kidipu	k i d i p u	k i d i p u						
-984	501	K	castreeren	castrate	kiediepoe (èq)èhoenè		kidipu (E')EhunE	k i d i p u # ( E ' ) E h u n E	k i d i p u # ( ɛ ʔ ) ɛ h u n ɛ						
-985	501	K	kreupel, mank	lame, limping	kiedjaieie(j)aq	341	kijaii(y)a'	k i j a i i ( y ) a '	k i d͡ʒ a i i ( j ) a ʔ						
+984	501	K	castreeren	castrate	kiediepoe_(èq)èhoenè		kidipu_(E')EhunE	k i d i p u _ ( E ' ) E h u n E	k i d i p u _ ( ɛ ʔ ) ɛ h u n ɛ						
+985	501	K	kreupel , mank	lame , limping	kiedjaieie(j)aq	341	kijaii(y)a'	k i j a i i ( y ) a '	k i d͡ʒ a i i ( j ) a ʔ						
 986	501	K	het pikken van vogels	the pecking of birds	kiedjie		kiji	k i j i	k i d͡ʒ i						
-987	501	K	verdwaald, dwalen	lost, wandering	kiedjiedjieö		kijiji'o	k i j i j i ' o	k i d͡ʒ i d͡ʒ i ʔ o						
+987	501	K	verdwaald , dwalen	lost , wandering	kiedjiedjieö		kijiji'o	k i j i j i ' o	k i d͡ʒ i d͡ʒ i ʔ o						
 988	501	K	gescheurd	torn	kiedjiekiedjie		kijikiji	k i j i k i j i	k i d͡ʒ i k i d͡ʒ i						
 989	501	K	erfgenaam	heir	kiedjoro		kijoro	k i j o r o	k i d͡ʒ o r o						
-990	501	K	als, evenals, zooals	as, like, as	kiedo	392	kido	k i d o	k i d o						
+990	501	K	als , evenals , zooals	as , like , as	kiedo	392	kido	k i d o	k i d o						
 991	501	K	sluikharig	straight-haired	kiedobieka	388	kidobika	k i d o b i k a	k i d o b i k a						
-992	501	K	macht, volmacht, kracht, machtig, gezaghebbend, in staat tot iets	power, proxy, strength, mighty, authoritative, capable of something	kiedodo		kidodo	k i d o d o	k i d o d o						
-993	501	K	stamvader	progenitor	kiedodo iedjie	343	kidodo iji	k i d o d o # i j i	k i d o d o # i d͡ʒ i						
-994	501	K	welig, frisch van planten	lush, fresh plants	kiedoropoq		kidoropo'	k i d o r o p o '	k i d o r o p o ʔ						
-995	501	K	afweren, afwenden	fend off, turn away	kieè(ja)		kiE(ya)	k i E ( y a )	k i ɛ ( j a )						
-996	502	K	krom, gebogen, verkromd	crooked, bent, warped	kièèlo		kiElo	k i E l o	k i ɛ l o						
+992	501	K	macht , volmacht , kracht , machtig , gezaghebbend , in staat tot iets	power , proxy , strength , mighty , authoritative , capable of something	kiedodo		kidodo	k i d o d o	k i d o d o						
+993	501	K	stamvader	progenitor	kiedodo_iedjie	343	kidodo_iji	k i d o d o _ i j i	k i d o d o _ i d͡ʒ i						
+994	501	K	welig , frisch van planten	lush , fresh plants	kiedoropoq		kidoropo'	k i d o r o p o '	k i d o r o p o ʔ						
+995	501	K	afweren , afwenden	fend off , turn away	kieè(ja)		kiE(ya)	k i E ( y a )	k i ɛ ( j a )						
+996	502	K	krom , gebogen , verkromd	crooked , bent , warped	kièèlo		kiElo	k i E l o	k i ɛ l o						
 997	502	K	erectie van den penis	erection of the penis	kieènoe		kiEnu	k i E n u	k i ɛ n u						
-998	502	K	zout, brak	saline, brackish	kiehiebie(j)a		kihibi(y)a	k i h i b i ( y ) a	k i ç i b i ( j ) a						
+998	502	K	zout , brak	saline , brackish	kiehiebie(j)a		kihibi(y)a	k i h i b i ( y ) a	k i ç i b i ( j ) a						
 999	502	K	een weinig	a little	kiehiema(na)		kihima(na)	k i h i m a ( n a )	k i ç i m a ( n a )						
-1000	502	K	goedkoop, laag in prijs	cheap, low in price	kiehiema(na)èodie	366	kihima(na)Eodi	k i h i m a ( n a ) E o d i	k i ç i m a ( n a ) ɛ o d i						
-1001	502	K	uitgebluscht van vuur van licht	extinguished, of fire and light	kiehieoba		kihioba	k i h i o b a	k i ç i o b a						
-1002	502	K	deugdzaamheid, waarde, nut	virtue, value, utility	kiehoè(j)a		kihu(y)a	k i h u ( y ) a	k i ç u ( j ) a						
+1000	502	K	goedkoop , laag in prijs	cheap , low in price	kiehiema(na)èodie	366	kihima(na)Eodi	k i h i m a ( n a ) E o d i	k i ç i m a ( n a ) ɛ o d i						
+1001	502	K	uitgebluscht van vuur van licht	extinguished , of fire and light	kiehieoba		kihioba	k i h i o b a	k i ç i o b a						
+1002	502	K	deugdzaamheid , waarde , nut	virtue , value , utility	kiehoè(j)a		kihu(y)a	k i h u ( y ) a	k i ç u ( j ) a						
 1003	502	K	ongehuwd	unmarried	kiehohoda(q)		kihohoda(')	k i h o h o d a ( ' )	k i ç o h o d a ( ʔ )						
-1004	502	K	gewond, wond	injured, wound	kieiedoka		kiidoka	k i i d o k a	k i i d o k a						
-1005	502	K	verschrikt, ontsteld, onthutst	startled, dismayed, staggered	kieie(j)oèdaha	367	kii(y)udaha	k i i ( y ) u d a h a	k i i ( j ) u d a h a						
-1006	502	K	nevel, mist	mist, fog	kieiepo	368	kiipo	k i i p o	k i i p o						
+1004	502	K	gewond , wond	injured , wound	kieiedoka		kiidoka	k i i d o k a	k i i d o k a						
+1005	502	K	verschrikt , ontsteld , onthutst	startled , dismayed , staggered	kieie(j)oèdaha	367	kii(y)udaha	k i i ( y ) u d a h a	k i i ( j ) u d a h a						
+1006	502	K	nevel , mist	mist , fog	kieiepo	368	kiipo	k i i p o	k i i p o						
 1007	502	K	zekere pisangsoort	certain pisang species	kieietjo		kiico	k i i c o	k i i t͡ʃ o						
-1008	502	K	hij, zij	he, she	kie(j)a		ki(y)a	k i ( y ) a	k i ( j ) a						
+1008	502	K	hij , zij	he , she	kie(j)a		ki(y)a	k i ( y ) a	k i ( j ) a						
 1009	502	K	er niet zijn	be absent	kie(j)abaq	330	ki(y)aba'	k i ( y ) a b a '	k i ( j ) a b a ʔ						
-1010	502	K	vertrouwen , hopen	trust , hope	kie(j)abaq iekèo	332	ki(y)aba' ikEo	k i ( y ) a b a ' # i k E o	k i ( j ) a b a ʔ # i k ɛ o						
+1010	502	K	vertrouwen , hopen	trust , hope	kie(j)abaq_iekèo	332	ki(y)aba'_ikEo	k i ( y ) a b a ' _ i k E o	k i ( j ) a b a ʔ _ i k ɛ o						
 1011	502	K	eene getah leverende boomsoort (balam)	a sap-/latex-yielding tree species (balam)	kie(j)ahariedjoe		ki(y)ahariju	k i ( y ) a h a r i j u	k i ( j ) a h a r i d͡ʒ u						
 1012	502	K	waarmede een in China geboren Chinees wordt aangesproken	By which a Chinese born in China is addressed	kie(j)aie		ki(y)ai	k i ( y ) a i	k i ( j ) a i						
-1013	502	K	woelen in den slaap, onrustig slapen	tossing in your sleep, sleeping restlessly	kie(j)oenano	338	ki(y)unano	k i ( y ) u n a n o	k i ( j ) u n a n o						
-1014	502	K	verschrikt, ontsteld	startled, dismayed	kie(j)oèdoha	339	ki(y)udoha	k i ( y ) u d o h a	k i ( j ) u d o h a						
-1015	502	K	niet goed, niet in den haak, niet gaaf, versleten	not good, not right, not flawless, worn out	kie(j)oha	333	ki(y)oha	k i ( y ) o h a	k i ( j ) o h a						
-1016	502	K	licht, daglicht	light, daylight	kie(j)oho		ki(y)oho	k i ( y ) o h o	k i ( j ) o h o						
-1017	502	K	e.s.v. boom (baroe), van welks bast touw wordt vervaardigd	e.s.v. tree (baroe), from whose bark rope is made	kie(j)okko		ki(y)okko	k i ( y ) o k k o	k i ( j ) o k k o						
-1018	502	K	ingevallen van de oogen of de wangen, vervallen van het gelaat	sunken of the eyes or cheeks, decay of the face	kie(j)opèka		ki(y)opEka	k i ( y ) o p E k a	k i ( j ) o p ɛ k a						
+1013	502	K	woelen in den slaap , onrustig slapen	tossing in your sleep , sleeping restlessly	kie(j)oenano	338	ki(y)unano	k i ( y ) u n a n o	k i ( j ) u n a n o						
+1014	502	K	verschrikt , ontsteld	startled , dismayed	kie(j)oèdoha	339	ki(y)udoha	k i ( y ) u d o h a	k i ( j ) u d o h a						
+1015	502	K	niet goed , niet in den haak , niet gaaf , versleten	not good , not right , not flawless , worn out	kie(j)oha	333	ki(y)oha	k i ( y ) o h a	k i ( j ) o h a						
+1016	502	K	licht , daglicht	light , daylight	kie(j)oho		ki(y)oho	k i ( y ) o h o	k i ( j ) o h o						
+1017	502	K	e.s.v. boom (baroe) , van welks bast touw wordt vervaardigd	e.s.v. tree (baroe) , from whose bark rope is made	kie(j)okko		ki(y)okko	k i ( y ) o k k o	k i ( j ) o k k o						
+1018	502	K	ingevallen van de oogen of de wangen , vervallen van het gelaat	sunken of the eyes or cheeks , decay of the face	kie(j)opèka		ki(y)opEka	k i ( y ) o p E k a	k i ( j ) o p ɛ k a						
 1019	502	K	naar beneden springen	jump down	kie(j)oqoqaq		ki(y)o'o'a'	k i ( y ) o ' o ' a '	k i ( j ) o ʔ o ʔ a ʔ						
-1020	502	K	vergeten zijn, vergeten	being forgotten, forgotten	kiekaäboe		kika'abu	k i k a ' a b u	k i k a ʔ a b u						
+1020	502	K	vergeten zijn , vergeten	being forgotten , forgotten	kiekaäboe		kika'abu	k i k a ' a b u	k i k a ʔ a b u						
 1021	502	K	kaal van het hoofd	bald head	kiekaäna		kika'ana	k i k a ' a n a	k i k a ʔ a n a						
-1022	502	K	ergens aan of in vastzitten; verhinderd, belet	stuck to or in something; prevented, impeded	kiekabiedja		kikabija	k i k a b i j a	k i k a b i d͡ʒ a						
-1023	502	K	tegenaanloopen, stooten	run into, bump into	kiekahaoeba		kikahauba	k i k a h a u b a	k i k a h a u b a						
-1024	502	K	verbaasd, verstomd, verbaasd staan te kijken	astonished, perplexed, looking on in amazement	kiekaoba		kikaoba	k i k a o b a	k i k a o b a						
-1025	502	K	stuk, in stukken zijn, in stukken breken, gebarsten, gespleten, gekloofd	broken, be in pieces, break into pieces, cracked, split, cleaved	kiekaraq(a)		kikara'(a)	k i k a r a ' ( a )	k i k a r a ʔ ( a )						
-1026	502	K	met stukken er af, uitvallen van tanden en kiezen	with pieces off, teeth falling out	kiekĕnènaq		kikėnEna'	k i k ė n E n a '	k i k ə n ɛ n a ʔ						
-1027	502	K	tam, mak	tame, tame	kiekĕroa		kikėroa	k i k ė r o a	k i k ə r o a						
+1022	502	K	ergens aan of in vastzitten ; verhinderd , belet	stuck to or in something ; prevented , impeded	kiekabiedja		kikabija	k i k a b i j a	k i k a b i d͡ʒ a						
+1023	502	K	tegenaanloopen , stooten	run into , bump into	kiekahaoeba		kikahauba	k i k a h a u b a	k i k a h a u b a						
+1024	502	K	verbaasd , verstomd , verbaasd staan te kijken	astonished , perplexed , looking on in amazement	kiekaoba		kikaoba	k i k a o b a	k i k a o b a						
+1025	502	K	stuk , in stukken zijn , in stukken breken , gebarsten , gespleten , gekloofd	broken , be in pieces , break into pieces , cracked , split , cleaved	kiekaraq(a)		kikara'(a)	k i k a r a ' ( a )	k i k a r a ʔ ( a )						
+1026	502	K	met stukken er af , uitvallen van tanden en kiezen	with pieces off , teeth falling out	kiekĕnènaq		kikėnEna'	k i k ė n E n a '	k i k ə n ɛ n a ʔ						
+1027	502	K	tam , mak	tame , tame	kiekĕroa		kikėroa	k i k ė r o a	k i k ə r o a						
 1028	502	K	berst in vruchten	tear in fruits	kiekèèla		kikEEla	k i k E E l a	k i k ɛ ɛ l a						
-1029	503	K	weggezonken bijv. in zand enz.; verzonken, vergaan, te gronde gaan	sunk e.g. in sand etc.; sunk, perished, ruined	kiekè(è)oe(w)a	369	kikE(E)u(w)a	k i k E ( E ) u ( w ) a	k i k ɛ ( ɛ ) u ( w ) a						
-1030	503	K	verdwenen, verloren, weggeraakt	disappeared, lost, gone	kiekèora(q)		kikEora(')	k i k E o r a ( ' )	k i k ɛ o r a ( ʔ )						
+1029	503	K	weggezonken bijv. in zand enz. ; verzonken , vergaan , te gronde gaan	sunk e.g. in sand etc. ; sunk , perished , ruined	kiekè(è)oe(w)a	369	kikE(E)u(w)a	k i k E ( E ) u ( w ) a	k i k ɛ ( ɛ ) u ( w ) a						
+1030	503	K	verdwenen , verloren , weggeraakt	disappeared , lost , gone	kiekèora(q)		kikEora(')	k i k E o r a ( ' )	k i k ɛ o r a ( ʔ )						
 1031	503	K	het ploffen van iets zwaars in het water	the thud of something heavy in the water	kiekèpoqä		kikEpo'a	k i k E p o ' a	k i k ɛ p o ʔ a						
 1032	503	K	inzakken van de voeten	sinking of the feet	kiekèpoqoe(w)a	370	kikEpo'u(w)a	k i k E p o ' u ( w ) a	k i k ɛ p o ʔ u ( w ) a						
-1033	503	K	stampen, aanstampen	mashing, stamping	kiekèqie		kikE'i	k i k E ' i	k i k ɛ ʔ i						
-1034	503	K	zijn, wezen, bestaan, leven, gebeuren, er is	being, being, existence, life, happening, there is	kiekie(j)a	371	kiki(y)a	k i k i ( y ) a	k i k i ( j ) a						
-1035	503	K	tegenstribbelen, zich verzetten	balk, resist	kiekie(j)aqkie(j)aq		kiki(y)a'ki(y)a'	k i k i ( y ) a ' k i ( y ) a '	k i k i ( j ) a ʔ k i ( j ) a ʔ						
-1036	503	K	alleen overblijven, achterblijven, blijven liggen van werk	left alone, left behind, left over from work	kiekie(j)ara		kiki(y)ara	k i k i ( y ) a r a	k i k i ( j ) a r a						
-1037	503	K	gew. verbonden met: «èbaka», knipoogen	usually connected with: “èbaka”, winking	kiekie(j)o		kiki(y)o	k i k i ( y ) o	k i k i ( j ) o	èbaka	Ebaka	E b a k a	214 ; 215 ; 234	ɛ b a k a	
+1033	503	K	stampen , aanstampen	mashing , stamping	kiekèqie		kikE'i	k i k E ' i	k i k ɛ ʔ i						
+1034	503	K	zijn , wezen , bestaan , leven , gebeuren , er is	being , being , existence , life , happening , there is	kiekie(j)a	371	kiki(y)a	k i k i ( y ) a	k i k i ( j ) a						
+1035	503	K	tegenstribbelen , zich verzetten	balk , resist	kiekie(j)aqkie(j)aq		kiki(y)a'ki(y)a'	k i k i ( y ) a ' k i ( y ) a '	k i k i ( j ) a ʔ k i ( j ) a ʔ						
+1036	503	K	alleen overblijven , achterblijven , blijven liggen van werk	left alone , left behind , left over from work	kiekie(j)ara		kiki(y)ara	k i k i ( y ) a r a	k i k i ( j ) a r a						
+1037	503	K	gew. verbonden met : «èbaka» , knipoogen	usually connected with : “èbaka” , winking	kiekie(j)o		kiki(y)o	k i k i ( y ) o	k i k i ( j ) o	èbaka	Ebaka	E b a k a	214	ɛ b a k a	
+1037	503	K	gew. verbonden met : «èbaka» , knipoogen	usually connected with : “èbaka” , winking	kiekie(j)o		kiki(y)o	k i k i ( y ) o	k i k i ( j ) o	èbaka	Ebaka	E b a k a	215	ɛ b a k a	
+1037	503	K	gew. verbonden met : «èbaka» , knipoogen	usually connected with : “èbaka” , winking	kiekie(j)o		kiki(y)o	k i k i ( y ) o	k i k i ( j ) o	èbaka	Ebaka	E b a k a	234	ɛ b a k a	
 1038	503	K	fijn hakken zooals fricadel	finely chopped like meatballs	kiekienie		kikini	k i k i n i	k i k i n i						
-1039	503	K	zorg, moeite, last	care, trouble, burden	kiekoekoe(q)ö	372	kikuku(')u̇	k i k u k u ( ' ) u̇	k i k u k u ( ʔ ) ɨ						
+1039	503	K	zorg , moeite , last	care , trouble , burden	kiekoekoe(q)ö	372	kikuku(')u̇	k i k u k u ( ' ) u̇	k i k u k u ( ʔ ) ɨ						
 1040	503	K	blazen van slangen en katten	hissing of snakes and cats	kiekoho		kikoho	k i k o h o	k i k o h o						
-1041	503	K	vloed, hoog water	high tide, high water	kiekohodaq		kikohoda'	k i k o h o d a '	k i k o h o d a ʔ						
+1041	503	K	vloed , hoog water	high tide , high water	kiekohodaq		kikohoda'	k i k o h o d a '	k i k o h o d a ʔ						
 1042	503	K	zitten van vogels of als een vogel op boomtakken	sitting of birds or as a bird on tree branches	kiekoko		kikoko	k i k o k o	k i k o k o						
 1043	503	K	kittelen	tickle	kiekokonie(j)a	408	kikokoni(y)a	k i k o k o n i ( y ) a	k i k o k o n i ( j ) a	èkonienie	Ekonini	E k o n i n i	477	ɛ k o n i n i	
-1044	503	K	slap, loshangend, niet gespannen	limp, loose, not tense	kiekononaq		kikonona'	k i k o n o n a '	k i k o n o n a ʔ						
-1045	503	K	een hoofddeksel vervaardigd van rottan, pandanus of nipahblad, den vorm hebbende van eene phrygische muts	a headgear made of rattan, pandanus or nipah leaf, having the shape of a phrygian cap	kiekooe(w)a		kikou(w)a	k i k o u ( w ) a	k i k o u ( w ) a						
-1046	503	K	nauw, eng, smal; ook: ondoordringbaar	narrow, narrow, narrow; also: impenetrable	kiekoöka		kiko'oka	k i k o ' o k a	k i k o ʔ o k a						
-1047	503	K	bedaard, tot rust gekomen van wind, van eene onstuimige zee; kalm, bedaard van water	subdued, calmed down wind, turbulent sea; calm, calmed down water	kiekoro(w)a		kikoro(w)a	k i k o r o ( w ) a	k i k o r o ( w ) a						
+1044	503	K	slap , loshangend , niet gespannen	limp , loose , not tense	kiekononaq		kikonona'	k i k o n o n a '	k i k o n o n a ʔ						
+1045	503	K	een hoofddeksel vervaardigd van rottan , pandanus of nipahblad , den vorm hebbende van eene phrygische muts	a headgear made of rattan , pandanus or nipah leaf , having the shape of a phrygian cap	kiekooe(w)a		kikou(w)a	k i k o u ( w ) a	k i k o u ( w ) a						
+1046	503	K	nauw , eng , smal ; ook : ondoordringbaar	narrow , narrow , narrow ; also : impenetrable	kiekoöka		kiko'oka	k i k o ' o k a	k i k o ʔ o k a						
+1047	503	K	bedaard , tot rust gekomen van wind , van eene onstuimige zee ; kalm , bedaard van water	subdued , calmed down wind , turbulent sea ; calm , calmed down water	kiekoro(w)a		kikoro(w)a	k i k o r o ( w ) a	k i k o r o ( w ) a						
 1048	503	K	zekere boomsoort met eetbare vruchten (kĕtapang)	Certain tree species with edible fruits (kĕtapang)	kielaoeloe		kilaulu	k i l a u l u	k i l a u l u						kĕtapang
-1049	503	K	haat, nijd	hate, envy	kiemèmè èbahaoeq		kimEmE Ebahau'	k i m E m E # E b a h a u '	k i m ɛ m ɛ # ɛ b a h a u ʔ						
+1049	503	K	haat , nijd	hate , envy	kiemèmè_èbahaoeq		kimEmE_Ebahau'	k i m E m E _ E b a h a u '	k i m ɛ m ɛ _ ɛ b a h a u ʔ						
 1050	503	K	komkommer	cucumber	kiemoenie		kimuni	k i m u n i	k i m u n i						
-1051	503	K	leugenachtig, leugen, onwaarheid, onwaar	lying, lie, falsehood, untrue	kiemoenie(j)o		kimuni(y)o	k i m u n i ( y ) o	k i m u n i ( j ) o						
+1051	503	K	leugenachtig , leugen , onwaarheid , onwaar	lying , lie , falsehood , untrue	kiemoenie(j)o		kimuni(y)o	k i m u n i ( y ) o	k i m u n i ( j ) o						
 1052	503	K	schaduw	shadow	kiemomojo		kimomoyo	k i m o m o y o	k i m o m o j o						
-1053	503	K	afbreken, slechten; bederven, geschonden, vernield	demolish, tear down; spoil, violated, detroyed	kienanaja		kinanaya	k i n a n a y a	k i n a n a j a						
-1054	503	K	vlak, effen	flat, level	kienanapa	373	kinanapa	k i n a n a p a	k i n a n a p a						
-1055	503	K	uitstooten van de oogtanden, eene mutilatie welke niet meer plaats heeft	removal of the eyeteeth, a mutilation which no longer takes place	kienienaqèkaq		kinina'Eka'	k i n i n a ' E k a '	k i n i n a ʔ ɛ k a ʔ						
+1053	503	K	afbreken , slechten ; bederven , geschonden , vernield	demolish , tear down ; spoil , violated , detroyed	kienanaja		kinanaya	k i n a n a y a	k i n a n a j a						
+1054	503	K	vlak , effen	flat , level	kienanapa	373	kinanapa	k i n a n a p a	k i n a n a p a						
+1055	503	K	uitstooten van de oogtanden , eene mutilatie welke niet meer plaats heeft	removal of the eyeteeth , a mutilation which no longer takes place	kienienaqèkaq		kinina'Eka'	k i n i n a ' E k a '	k i n i n a ʔ ɛ k a ʔ						
 1056	503	K	glimlachen	smile	kienienèqa		kininE'a	k i n i n E ' a	k i n i n ɛ ʔ a						
-1057	503	K	hoe zit dat nu, hoe komt dat	how about that, how come	kienjono		kiñono	k i ñ o n o	k i ɲ o n o						
-1058	503	K	duiken, indompelen, indoopen	diving, dipping, immersion	kieno		kino	k i n o	k i n o						
-1059	503	K	drijven, aan de oppervlakte van het water komen	float, come to the surface of the water	kienoäo		kino'ao	k i n o ' a o	k i n o ʔ a o						
+1057	503	K	hoe zit dat nu , hoe komt dat	how about that , how come	kienjono		kiñono	k i ñ o n o	k i ɲ o n o						
+1058	503	K	duiken , indompelen , indoopen	diving , dipping , immersion	kieno		kino	k i n o	k i n o						
+1059	503	K	drijven , aan de oppervlakte van het water komen	float , come to the surface of the water	kienoäo		kino'ao	k i n o ' a o	k i n o ʔ a o						
 1060	503	K	verhemelte	palate	kienoeoeka		kinu'uka	k i n u ' u k a	k i n u ʔ u k a						
-1061	504	K	waarvoor, waartoe, waarom	for what, to what, why	kienono		kinono	k i n o n o	k i n o n o						
-1062	504	K	op welke wijze	in what way	kienono: è(j)a	374	kinono: E(y)a	k i n o n o : # E ( y ) a	k i n o n o : # ɛ ( j ) a						
+1061	504	K	waarvoor , waartoe , waarom	for what , to what , why	kienono		kinono	k i n o n o	k i n o n o						
+1062	504	K	op welke wijze	in what way	kienono:_è(j)a	374	kinono:_E(y)a	k i n o n o : _ E ( y ) a	k i n o n o : _ ɛ ( j ) a						
 1063	504	K	hoe dat nu	how that now	è(j)adie(j)a	62	E(y)adi(y)a	E ( y ) a d i ( y ) a	ɛ ( j ) a d i ( j ) a						
 1064	504	K	hoe dit nu	how this now	è(j)aè		E(y)aE	E ( y ) a E	ɛ ( j ) a ɛ						
-1065	504	K	tred, stap	pace, step	kienoöna(w)aie		kino'ona(w)ai	k i n o ' o n a ( w ) a i	k i n o ʔ o n a ( w ) a i						
-1066	504	K	uitgestort, vergoten	poured out, shed	kienoqè(j)a	375	kino'E(y)a	k i n o ' E ( y ) a	k i n o ʔ ɛ ( j ) a						
+1065	504	K	tred , stap	pace , step	kienoöna(w)aie		kino'ona(w)ai	k i n o ' o n a ( w ) a i	k i n o ʔ o n a ( w ) a i						
+1066	504	K	uitgestort , vergoten	poured out , shed	kienoqè(j)a	375	kino'E(y)a	k i n o ' E ( y ) a	k i n o ʔ ɛ ( j ) a						
 1067	504	K	dutten	nap	kiodèa	378	kiodEa	k i o d E a	k i o d ɛ a						
-1068	504	K	gekerfd, schaardig, met afgebrokkelden rand	carved, scissor-like, with crumbled edge	kieoenèkaq		kiunEka'	k i u n E k a '	k i u n ɛ k a ʔ						
-1069	504	K	langzaam, traag, talmend, laat, te laat; zorgeloos, onachtzaam, ergens niet aan denken	slow, sluggish, lingering, late, too late; careless, negligent, not thinking about something	kieojo		kioyo	k i o y o	k i o j o						
+1068	504	K	gekerfd , schaardig , met afgebrokkelden rand	carved , scissor-like , with crumbled edge	kieoenèkaq		kiunEka'	k i u n E k a '	k i u n ɛ k a ʔ						
+1069	504	K	langzaam , traag , talmend , laat , te laat ; zorgeloos , onachtzaam , ergens niet aan denken	slow , sluggish , lingering , late , too late ; careless , negligent , not thinking about something	kieojo		kioyo	k i o y o	k i o j o						
 1070	504	K	luidkeels lachen	loudly laughing	kieokahaie	376	kiokahai	k i o k a h a i	k i o k a h a i						
 1071	504	K	verdord van bloemen en planten	withered flowers and plants	kieonieka	377	kionika	k i o n i k a	k i o n i k a						
-1072	504	K	dicht van het loof der boomen, van bloesems	close from the foliage of trees, from blossoms	kieoö		kio'o	k i o ' o	k i o ʔ o						
-1073	504	K	sprong, het springen	jump, jumping	kieoöäaq		kio'o'aa'	k i o ' o ' a a '	k i o ʔ o ʔ a a ʔ						
+1072	504	K	dicht van het loof der boomen , van bloesems	close from the foliage of trees , from blossoms	kieoö		kio'o	k i o ' o	k i o ʔ o						
+1073	504	K	sprong , het springen	jump , jumping	kieoöäaq		kio'o'aa'	k i o ' o ' a a '	k i o ʔ o ʔ a a ʔ						
 1074	504	K	ontginnen van den grond door zuivering van onkruid	clearing the soil by purging weeds	kieoöie		kio'oi	k i o ' o i	k i o ʔ o i						
-1075	504	K	onderdoen, verliezen	be inferior, lose	kieoöno		kio'ono	k i o ' o n o	k i o ʔ o n o						
-1076	504	K	ontworteld, uitgerukt	uprooted, torn out	kieoönopa		kio'onopa	k i o ' o n o p a	k i o ʔ o n o p a						
+1075	504	K	onderdoen , verliezen	be inferior , lose	kieoöno		kio'ono	k i o ' o n o	k i o ʔ o n o						
+1076	504	K	ontworteld , uitgerukt	uprooted , torn out	kieoönopa		kio'onopa	k i o ' o n o p a	k i o ʔ o n o p a						
 1077	504	K	tien	ten	kiepa(a)oeq	345	kipa(a)u'	k i p a ( a ) u '	k i p a ( a ) u ʔ						
-1078	504	K	krakeel, harrewarrerij	squabble, squabbling	kiepadie; kiepadieoeiedjie	379	kipadi; kipadiuiji	k i p a d i ; # k i p a d i u i j i	k i p a d i ; # k i p a d i u i d͡ʒ i						
-1079	504	K	woordentwist, getier, leven, rumoer	argument, clamor, life, noise	kiepahoe(w)a	352	kipahu(w)a	k i p a h u ( w ) a	k i p a h u ( w ) a						
+1078	504	K	krakeel , harrewarrerij	squabble , squabbling	kiepadie	379	kipadi	k i p a d i	k i p a d i						
+1078	504	K	krakeel , harrewarrerij	squabble , squabbling	kiepadieoeiedjie	379	kipadiuiji	k i p a d i u i j i	k i p a d i u i d͡ʒ i						
+1079	504	K	woordentwist , getier , leven , rumoer	argument , clamor , life , noise	kiepahoe(w)a	352	kipahu(w)a	k i p a h u ( w ) a	k i p a h u ( w ) a						
 1080	504	K	bleek van gelaatskleur	pale complexion	kiepaka		kipaka	k i p a k a	k i p a k a						
 1081	504	K	een bekende	an acquaintance	kiepakaowaq		kipakaowa'	k i p a k a o w a '	k i p a k a o w a ʔ						
-1082	504	K	vermengd, dooreen, ondereengemengd	mixed, mixed through, unmixed	kiepakiedja		kipakija	k i p a k i j a	k i p a k i d͡ʒ a						
-1083	504	K	schemering, schemerdonker	dusk, twilight	kiepa; kiepakiepa pahoeoenaq	353	kipa; kipakipa pahu'una'	k i p a ; # k i p a k i p a # p a h u ' u n a '	k i p a ; # k i p a k i p a # p a h u ʔ u n a ʔ						
-1084	504	K	het bij iets komen, ontmoeten, tegenkomen	coming to something, meeting, encountering	kiepakobaq		kipakoba'	k i p a k o b a '	k i p a k o b a ʔ						
-1085	504	K	stief, in stiefvader enz	step, in stepfather etc	kiepakoeka		kipakuka	k i p a k u k a	k i p a k u k a						
-1086	504	K	rimpel, plooi	wrinkle, fold	kiepakoekoeoedie		kipakuku'udi	k i p a k u k u ' u d i	k i p a k u k u ʔ u d i						
-1087	504	K	de juiste richting, de juiste plaats	the right direction, the right place	kiepakoko	380	kipakoko	k i p a k o k o	k i p a k o k o						
-1088	504	K	bedorven, geschonden, vernield	corrupted, violated, destroyed	kiepakokokie	381	kipakokoki	k i p a k o k o k i	k i p a k o k o k i						
+1082	504	K	vermengd , dooreen , ondereengemengd	mixed , mixed through , unmixed	kiepakiedja		kipakija	k i p a k i j a	k i p a k i d͡ʒ a						
+1083	504	K	schemering , schemerdonker	dusk , twilight	kiepa	353	kipa	k i p a	k i p a						
+1083	504	K	schemering , schemerdonker	dusk , twilight	kiepakiepa_pahoeoenaq	353	kipakipa_pahu'una'	k i p a k i p a _ p a h u ' u n a '	k i p a k i p a _ p a h u ʔ u n a ʔ						
+1084	504	K	het bij iets komen , ontmoeten , tegenkomen	coming to something , meeting , encountering	kiepakobaq		kipakoba'	k i p a k o b a '	k i p a k o b a ʔ						
+1085	504	K	stief , in stiefvader enz	step , in stepfather etc	kiepakoeka		kipakuka	k i p a k u k a	k i p a k u k a						
+1086	504	K	rimpel , plooi	wrinkle , fold	kiepakoekoeoedie		kipakuku'udi	k i p a k u k u ' u d i	k i p a k u k u ʔ u d i						
+1087	504	K	de juiste richting , de juiste plaats	the right direction , the right place	kiepakoko	380	kipakoko	k i p a k o k o	k i p a k o k o						
+1088	504	K	bedorven , geschonden , vernield	corrupted , violated , destroyed	kiepakokokie	381	kipakokoki	k i p a k o k o k i	k i p a k o k o k i						
 1089	504	K	verbrijzeld tengevolge van een val	crushed as a result of a fall	kiepamiemiehieka		kipamimihika	k i p a m i m i h i k a	k i p a m i m i ç i k a						
-1090	504	K	vol; gevuld, volkomen	full; filled, complete	kiepamo	354	kipamo	k i p a m o	k i p a m o						
+1090	504	K	vol ; gevuld , volkomen	full ; filled , complete	kiepamo	354	kipamo	k i p a m o	k i p a m o						
 1091	504	K	kroesharig	frizzy-haired	kiepamoemoeoeie		kipamumu'ui	k i p a m u m u ' u i	k i p a m u m u ʔ u i						
 1092	504	K	slapen van den voet	sleeping foot	kiepapakoe	351	kipapaku	k i p a p a k u	k i p a p a k u						
-1093	504	K	opeengedrongen, dicht op elkander gedrongen	huddled together, huddled together	kiepaqaq	355	kipa'a'	k i p a ' a '	k i p a ʔ a ʔ						
-1094	504	K	gek, zinneloos, zinsverbijstering	crazy, senseless, madness	kieparaèbahao(q)	382	kiparaEbahao(')	k i p a r a E b a h a o ( ' )	k i p a r a ɛ b a h a o ( ʔ )						
-1095	505	K	dicht, goed sluitend	dense, tight-fitting	kieparahpie		kiparahpi	k i p a r a h p i	k i p a r a h p i						
+1093	504	K	opeengedrongen , dicht op elkander gedrongen	huddled together , huddled together	kiepaqaq	355	kipa'a'	k i p a ' a '	k i p a ʔ a ʔ						
+1094	504	K	gek , zinneloos , zinsverbijstering	crazy , senseless , madness	kieparaèbahao(q)	382	kiparaEbahao(')	k i p a r a E b a h a o ( ' )	k i p a r a ɛ b a h a o ( ʔ )						
+1095	505	K	dicht , goed sluitend	dense , tight-fitting	kieparahpie		kiparahpi	k i p a r a h p i	k i p a r a h p i						
 1096	505	K	dom	stupid	kieparahopie		kiparahopi	k i p a r a h o p i	k i p a r a h o p i						
 1097	505	K	vlam	flame	kieparoa		kiparoa	k i p a r o a	k i p a r o a						
 1098	505	K	stom	stupid	kiepĕraiedie(j)og	383	kipėraidi(y)og	k i p ė r a i d i ( y ) o g	k i p ə r a i d i ( j ) o g						
-1099	505	K	weten, weten te doen, het kunnen, in staat zijn, knap, bedreven, verstandig	know, know how to do, be able, capable, clever, adept, wise	kiepĕhaie	357	kipėhai	k i p ė h a i	k i p ə h a i						
+1099	505	K	weten , weten te doen , het kunnen , in staat zijn , knap , bedreven , verstandig	know , know how to do , be able , capable , clever , adept , wise	kiepĕhaie	357	kipėhai	k i p ė h a i	k i p ə h a i						
 1100	505	K	kruipen van een kind	crawling of a child	kiepèhèboeöbo		kipEhEbu'obo	k i p E h E b u ' o b o	k i p ɛ h ɛ b u ʔ o b o	oöbo	o'obo	o ' o b o	605	o ʔ o b o	
-1101	505	K	doof, hardhoorig	deaf, hard of hearing	kiepèhodo	358	kipEhodo	k i p E h o d o	k i p ɛ h o d o						
-1102	505	K	los, ontglipt, uit de hand geschoten, ontsnapt	loose, slipped, out of control, escaped	kiepèoraq	356	kipEora'	k i p E o r a '	k i p ɛ o r a ʔ						
-1103	505	K	gezegd van eene rivier, die niet te diep is om te worden doorwaad	said of a river, which is not to deep to wade through	kiepiepie	359	kipipi	k i p i p i	k i p i p i						
-1104	505	K	tam, mak	tame, tame	kiepoäka		kipo'aka	k i p o ' a k a	k i p o ʔ a k a						
-1105	505	K	gebarsten, gespleten, gekloofd	cracked, split, cleaved	kiepoäraq	384	kipo'ara'	k i p o ' a r a '	k i p o ʔ a r a ʔ						
-1106	505	K	ontspruiten, groeien, ontstaan	sprout, grow, emerge	kiepoedieka	385	kipudika	k i p u d i k a	k i p u d i k a						
+1101	505	K	doof , hardhoorig	deaf , hard of hearing	kiepèhodo	358	kipEhodo	k i p E h o d o	k i p ɛ h o d o						
+1102	505	K	los , ontglipt , uit de hand geschoten , ontsnapt	loose , slipped , out of control , escaped	kiepèoraq	356	kipEora'	k i p E o r a '	k i p ɛ o r a ʔ						
+1103	505	K	gezegd van eene rivier , die niet te diep is om te worden doorwaad	said of a river , which is not to deep to wade through	kiepiepie	359	kipipi	k i p i p i	k i p i p i						
+1104	505	K	tam , mak	tame , tame	kiepoäka		kipo'aka	k i p o ' a k a	k i p o ʔ a k a						
+1105	505	K	gebarsten , gespleten , gekloofd	cracked , split , cleaved	kiepoäraq	384	kipo'ara'	k i p o ' a r a '	k i p o ʔ a r a ʔ						
+1106	505	K	ontspruiten , groeien , ontstaan	sprout , grow , emerge	kiepoedieka	385	kipudika	k i p u d i k a	k i p u d i k a						
 1107	505	K	opborrelen van kokend water	bubbling of boiling water	kiepoefoe	361	kipufu	k i p u f u	k i p u f u						
-1108	505	K	neerkomen, vallen	come down, fall	kiepoeoeda	362	kipu'uda	k i p u ' u d a	k i p u ʔ u d a						
-1109	505	K	zien, opnemen, bekijken, aanzien, afzien	seeing, recording, watching, contemplating, seeing off	kiepoe(w)a	360	kipu(w)a	k i p u ( w ) a	k i p u ( w ) a						
-1110	505	K	aannemen, zich bereid verklaren	accept, declare themselves willing	kiepohajĕ		kipohayė	k i p o h a y ė	k i p o h a j ə						
-1111	505	K	openspringen, uit elkander springen	pop open, jump apart	kiepokana	364	kipokana	k i p o k a n a	k i p o k a n a						
+1108	505	K	neerkomen , vallen	come down , fall	kiepoeoeda	362	kipu'uda	k i p u ' u d a	k i p u ʔ u d a						
+1109	505	K	zien , opnemen , bekijken , aanzien , afzien	seeing , recording , watching , contemplating , seeing off	kiepoe(w)a	360	kipu(w)a	k i p u ( w ) a	k i p u ( w ) a						
+1110	505	K	aannemen , zich bereid verklaren	accept , declare themselves willing	kiepohajĕ		kipohayė	k i p o h a y ė	k i p o h a j ə						
+1111	505	K	openspringen , uit elkander springen	pop open , jump apart	kiepokana	364	kipokana	k i p o k a n a	k i p o k a n a						
 1112	505	K	het glaga riet	the glaga reed	kiepokiepo	365	kipokipo	k i p o k i p o	k i p o k i p o						
 1113	505	K	dicht van den regen	dense with rain	kiepoö		kipo'o	k i p o ' o	k i p o ʔ o						
-1114	505	K	verbrijzeld, vergruisd	crushed, pulverised	kiepopoä	363	kipopo'a	k i p o p o ' a	k i p o p o ʔ a						
-1115	505	K	open, uit elkander	open, apart	kiepoqöaq		kipo'u̇a'	k i p o ' u̇ a '	k i p o ʔ ɨ a ʔ						
+1114	505	K	verbrijzeld , vergruisd	crushed , pulverised	kiepopoä	363	kipopo'a	k i p o p o ' a	k i p o p o ʔ a						
+1115	505	K	open , uit elkander	open , apart	kiepoqöaq		kipo'u̇a'	k i p o ' u̇ a '	k i p o ʔ ɨ a ʔ						
 1116	505	K	met de vlakke hand om de ooren slaan	slap around the ears with the flat of your hand	kieqja	386	ki'ya	k i ' y a	k i ʔ j a						
 1117	505	K	geneeskundige	physician	koahajo	409	koahayo	k o a h a y o	k o a h a j o	èko(q)hajo	Eko(')hayo	E k o ( ' ) h a y o	483	ɛ k o ( ʔ ) h a j o	
-1118	505	K	avond, nacht	evening, night	koahie(j)a	393	koahi(y)a	k o a h i ( y ) a	k o a h i ( j ) a						
-1119	505	K	middernacht	midnight	koahie(j)a kapoe	394	koahi(y)a kapu	k o a h i ( y ) a # k a p u	k o a h i ( j ) a # k a p u						
-1120	505	K	levend, frisch, versch	alive, fresh, fresh	köda		ku̇da	k u̇ d a	k ɨ d a						
-1121	505	K	het in eens doorslikken, opslikken	swallowing it at once, gobbling it up	kodo		kodo	k o d o	k o d o						
+1118	505	K	avond , nacht	evening , night	koahie(j)a	393	koahi(y)a	k o a h i ( y ) a	k o a h i ( j ) a						
+1119	505	K	middernacht	midnight	koahie(j)a_kapoe	394	koahi(y)a_kapu	k o a h i ( y ) a _ k a p u	k o a h i ( j ) a _ k a p u						
+1120	505	K	levend , frisch , versch	alive , fresh , fresh	köda		ku̇da	k u̇ d a	k ɨ d a						
+1121	505	K	het in eens doorslikken , opslikken	swallowing it at once , gobbling it up	kodo		kodo	k o d o	k o d o						
 1122	505	K	voorhoofd	forehead	koe		ku	k u	k u						
-1123	505	K	wanneer, als, toen	when, if, when	koeano	395	kuano	k u a n o	k u a n o						
-1124	505	K	vertellen, zeggen	tell, say	koedaqä		kuda'a	k u d a ' a	k u d a ʔ a						
-1125	505	K	van, afkomstig van	from, coming from	koedè		kudE	k u d E	k u d ɛ						
-1126	505	K	waar van daan, van waar	where from, from where	koedè: iejaha		kudE: iyaha	k u d E : # i y a h a	k u d ɛ : # i j a h a						
+1123	505	K	wanneer , als , toen	when , if , when	koeano	395	kuano	k u a n o	k u a n o						
+1124	505	K	vertellen , zeggen	tell , say	koedaqä		kuda'a	k u d a ' a	k u d a ʔ a						
+1125	505	K	van , afkomstig van	from , coming from	koedè		kudE	k u d E	k u d ɛ						
+1126	505	K	waar van daan , van waar	where from , from where	koedè:_iejaha		kudE:_iyaha	k u d E : _ i y a h a	k u d ɛ : _ i j a h a						
 1127	505	K	van binnen	within	iepoko		ipoko	i p o k o	i p o k o						
 1128	505	K	van buiten	outside	ietopo	286	itopo	i t o p o	i t o p o						
-1129	506	K	gene	that one; or: shyness	koedèja		kudEya	k u d E y a	k u d ɛ j a						
-1130	506	K	lichaam, 20 taka’s	body, 20 takas	koedodoka	150	kudodoka	k u d o d o k a	k u d o d o k a	taka	taka	t a k a	1371	t a k a	
-1131	506	K	uiterste punt, uiteinde, kaap	extreme point, tip, cape	koedoe	401	kudu	k u d u	k u d u						
-1132	506	K	hulp, bijstand; hulp verleenen, helpen	help, assistance; giving help, helping	koehaie		kuhai	k u h a i	k u h a i						
-1133	506	K	ruilen, wisselen, verruilen, verwisselen, veranderen van vorm	exchange, exchange, swap, change shape	koehèdie	404	kuhEdi	k u h E d i	k u h ɛ d i						
+1129	506	K	gene	that one ; or : shyness	koedèja		kudEya	k u d E y a	k u d ɛ j a						
+1130	506	K	lichaam , 20 taka’s	body , 20 takas	koedodoka	150	kudodoka	k u d o d o k a	k u d o d o k a	taka	taka	t a k a	1371	t a k a	
+1131	506	K	uiterste punt , uiteinde , kaap	extreme point , tip , cape	koedoe	401	kudu	k u d u	k u d u						
+1132	506	K	hulp , bijstand ; hulp verleenen , helpen	help , assistance ; giving help , helping	koehaie		kuhai	k u h a i	k u h a i						
+1133	506	K	ruilen , wisselen , verruilen , verwisselen , veranderen van vorm	exchange , exchange , swap , change shape	koehèdie	404	kuhEdi	k u h E d i	k u h ɛ d i						
 1134	506	K	veranderen van den wind	changing of the wind	koehèdie(j)aq	396	kuhEdi(y)a'	k u h E d i ( y ) a '	k u h ɛ d i ( j ) a ʔ						
 1135	506	K	jeukte	itched	koehiemaq		kuhima'	k u h i m a '	k u h i m a ʔ						
-1136	506	K	gaten in de ooren boren om er versierselen in te dragen	drilling holes in the ears to wear ornaments in them	koeie; koeie karieha	397	kui; kui kariha	k u i ; # k u i # k a r i h a	k u i ; # k u i # k a r i ç a	kiedie	kidi	k i d i	978	k i d i	
-1137	506	K	richting; doel	direction; aim	koeiehie		kuihi	k u i h i	k u i ç i						
-1138	506	K	juist, juist zijn, echt, waar, werkelijk, inderdaad	being right, right, real, true, indeed	koeienaq	398	kuina'	k u i n a '	k u i n a ʔ						
-1139	506	K	voortschuiven, wegschuiven, toeschuiven	push forward, push away, push forward	koejaq		kuya'	k u y a '	k u j a ʔ						
+1136	506	K	gaten in de ooren boren om er versierselen in te dragen	drilling holes in the ears to wear ornaments in them	koeie	397	kui	k u i	k u i	kiedie	kidi	k i d i	978	k i d i	
+1136	506	K	gaten in de ooren boren om er versierselen in te dragen	drilling holes in the ears to wear ornaments in them	koeie_karieha	397	kui_kariha	k u i _ k a r i h a	k u i _ k a r i ç a	kiedie	kidi	k i d i	978	k i d i	
+1137	506	K	richting ; doel	direction ; aim	koeiehie		kuihi	k u i h i	k u i ç i						
+1138	506	K	juist , juist zijn , echt , waar , werkelijk , inderdaad	being right , right , real , true , indeed	koeienaq	398	kuina'	k u i n a '	k u i n a ʔ						
+1139	506	K	voortschuiven , wegschuiven , toeschuiven	push forward , push away , push forward	koejaq		kuya'	k u y a '	k u j a ʔ						
 1140	506	K	lende	loin	koekaq		kuka'	k u k a '	k u k a ʔ						
 1141	506	K	zekere pisangsoort	certain pisang species	koekoebaka		kukubaka	k u k u b a k a	k u k u b a k a						
 1142	506	K	zekere boomsoort met goed deugdzaam timmerhout	certain tree species with good decent lumber	koemènoeè	400	kumEnuE	k u m E n u E	k u m ɛ n u ɛ						
 1143	506	K	fijntjes knijpen met vinger en duim	pinch gently with finger and thumb	koemoe		kumu	k u m u	k u m u						
-1144	506	K	drie steenen voor treeft, om het kooksel er op te zetten	three stones for the trivet, to put the cooking on it	koenajo		kunayo	k u n a y o	k u n a j o						
-1145	506	K	in de plaats van iets anders komen, vervangen, vergoeden, vergoeding	substitute for something else, replace, reimburse, compensate	koepèie		kupEi	k u p E i	k u p ɛ i						
+1144	506	K	drie steenen voor treeft , om het kooksel er op te zetten	three stones for the trivet , to put the cooking on it	koenajo		kunayo	k u n a y o	k u n a j o						
+1145	506	K	in de plaats van iets anders komen , vervangen , vergoeden , vergoeding	substitute for something else , replace , reimburse , compensate	koepèie		kupEi	k u p E i	k u p ɛ i						
 1146	506	K	de lippen	lips	koeripo	399	kuripo	k u r i p o	k u r i p o						
-1147	506	K	ingaan, binnengaan	enter, enter	koe(w)a		ku(w)a	k u ( w ) a	k u ( w ) a						
-1148	506	K	omlaag zien, bukken	looking down, stooping	koe(w)adie		ku(w)adi	k u ( w ) a d i	k u ( w ) a d i						
+1147	506	K	ingaan , binnengaan	enter , enter	koe(w)a		ku(w)a	k u ( w ) a	k u ( w ) a						
+1148	506	K	omlaag zien , bukken	looking down , stooping	koe(w)adie		ku(w)adi	k u ( w ) a d i	k u ( w ) a d i						
 1149	506	K	hut	hut	kohèaq		kohEa'	k o h E a '	k o h ɛ a ʔ						
 1150	506	K	op den schoot houden	hold on your lap	kohopaie	405	kohopai	k o h o p a i	k o h o p a i						
 1151	506	K	kleinkind	grandchild	kohopie(j)oe	406	kohopi(y)u	k o h o p i ( y ) u	k o h o p i ( j ) u						
-1152	506	K	verminderen, slinken	reduce, shrink	kokieha		kokiha	k o k i h a	k o k i ç a						
-1153	506	K	persen, drukken bij hardlijvigheid	pressing, pushing for constipation	kokoäaq		koko'aa'	k o k o ' a a '	k o k o ʔ a a ʔ						
-1154	506	K	gissen, meenen, denken, vermoeden, berekenen	guessing, thinking, conjecturing, calculating	kokoĕ		kokoė	k o k o ė	k o k o ə						
-1155	506	K	lui, traag	lazy, slow	kokoie(j)aèa		kokoi(y)aEa	k o k o i ( y ) a E a	k o k o i ( j ) a ɛ a						
-1156	506	K	naar buiten, naar buiten gaan, te voorschijn komen, uitgaan, uitkomen, voor den dag komen	go out, go out, emerge, go out, come out, emerge	kokona	407	kokona	k o k o n a	k o k o n a						
-1157	506	K	met elkander verzoend, vrede als einde van twist of oorlog	reconciled with each other, peace as the end of strife or war	(ko)koro(w)a		(ko)koro(w)a	( k o ) k o r o ( w ) a	( k o ) k o r o ( w ) a						
-1158	506	K	het aan beide einden van een stok over de schouders dragen van lasten, wegdragen	carrying loads on both ends of a stick over the shoulders, carrying away	kolè		kolE	k o l E	k o l ɛ						
-1159	507	K	los, vrij, ontkomen	loose, free, escape(d)	komojaqä		komoya'a	k o m o y a ' a	k o m o j a ʔ a						
-1160	507	K	modder, slib, slik	mud, silt, sludge	komokomo		komokomo	k o m o k o m o	k o m o k o m o						
-1161	507	K	verwelkt, verdord	withered, withered	konèka		konEka	k o n E k a	k o n ɛ k a						
+1152	506	K	verminderen , slinken	reduce , shrink	kokieha		kokiha	k o k i h a	k o k i ç a						
+1153	506	K	persen , drukken bij hardlijvigheid	pressing , pushing for constipation	kokoäaq		koko'aa'	k o k o ' a a '	k o k o ʔ a a ʔ						
+1154	506	K	gissen , meenen , denken , vermoeden , berekenen	guessing , thinking , conjecturing , calculating	kokoĕ		kokoė	k o k o ė	k o k o ə						
+1155	506	K	lui , traag	lazy , slow	kokoie(j)aèa		kokoi(y)aEa	k o k o i ( y ) a E a	k o k o i ( j ) a ɛ a						
+1156	506	K	naar buiten , naar buiten gaan , te voorschijn komen , uitgaan , uitkomen , voor den dag komen	go out , go out , emerge , go out , come out , emerge	kokona	407	kokona	k o k o n a	k o k o n a						
+1157	506	K	met elkander verzoend , vrede als einde van twist of oorlog	reconciled with each other , peace as the end of strife or war	(ko)koro(w)a		(ko)koro(w)a	( k o ) k o r o ( w ) a	( k o ) k o r o ( w ) a						
+1158	506	K	het aan beide einden van een stok over de schouders dragen van lasten , wegdragen	carrying loads on both ends of a stick over the shoulders , carrying away	kolè		kolE	k o l E	k o l ɛ						
+1159	507	K	los , vrij , ontkomen	loose , free , escape(d)	komojaqä		komoya'a	k o m o y a ' a	k o m o j a ʔ a						
+1160	507	K	modder , slib , slik	mud , silt , sludge	komokomo		komokomo	k o m o k o m o	k o m o k o m o						
+1161	507	K	verwelkt , verdord	withered , withered	konèka		konEka	k o n E k a	k o n ɛ k a						
 1162	507	K	12 u. ’s middags	12 noon	konohaq(?)		konoha'(?)	k o n o h a ' ( ? )	k o n o h a ʔ ( ? )						
-1163	507	K	afvieren, vieren van touw	loosening, loosening of rope	kononaq		konona'	k o n o n a '	k o n o n a ʔ						
-1164	507	K	rustbank, slaapbank	resting sofa, sofa bed	koöma		ko'oma	k o ' o m a	k o ʔ o m a						
-1165	507	K	wurm, rups	worm, caterpillar	kopènè		kopEnE	k o p E n E	k o p ɛ n ɛ						
+1163	507	K	afvieren , vieren van touw	loosening , loosening of rope	kononaq		konona'	k o n o n a '	k o n o n a ʔ						
+1164	507	K	rustbank , slaapbank	resting sofa , sofa bed	koöma		ko'oma	k o ' o m a	k o ʔ o m a						
+1165	507	K	wurm , rups	worm , caterpillar	kopènè		kopEnE	k o p E n E	k o p ɛ n ɛ						
 1166	507	K	eene soort van ebbenhout	a kind of ebony	kopèq		kopE'	k o p E '	k o p ɛ ʔ						
-1167	507	K	begraven, graf	buried, grave	kopo	402	kopo	k o p o	k o p o						
-1168	507	K	zuigen, opzuigen, inzuigen	suck, suck up, suck in	kopodieqie	403	kopodi'i	k o p o d i ' i	k o p o d i ʔ i						
+1167	507	K	begraven , graf	buried , grave	kopo	402	kopo	k o p o	k o p o						
+1168	507	K	zuigen , opzuigen , inzuigen	suck , suck up , suck in	kopodieqie	403	kopodi'i	k o p o d i ' i	k o p o d i ʔ i						
 1169	507	K	het in iets gezakt zijn	having sunk into something	koqoq	299	ko'o'	k o ' o '	k o ʔ o ʔ						
-1170	507	K	ronde plaats destijds aangetroffen onder de woning (bijenkorfvorm), dienende tot bewaarplaats van mandjes en ander huisraad	round place once found under the house (beehive shape), serving as storage place for baskets and other household goods	koqoqma		ko'o'ma	k o ' o ' m a	k o ʔ o ʔ m a						
-1171	507	K	hellen, overhellen	tilt, tilt over	koqowie		ko'owi	k o ' o w i	k o ʔ o w i						
-1172	507	K	kennis geven, mededeelen	notify, inform	koraq		kora'	k o r a '	k o r a ʔ						
+1170	507	K	ronde plaats destijds aangetroffen onder de woning (bijenkorfvorm) , dienende tot bewaarplaats van mandjes en ander huisraad	round place once found under the house (beehive shape) , serving as storage place for baskets and other household goods	koqoqma		ko'o'ma	k o ' o ' m a	k o ʔ o ʔ m a						
+1171	507	K	hellen , overhellen	tilt , tilt over	koqowie		ko'owi	k o ' o w i	k o ʔ o w i						
+1172	507	K	kennis geven , mededeelen	notify , inform	koraq		kora'	k o r a '	k o r a ʔ						
 1173	507	M	huwen	marry	ma(ä)hona		ma('a)hona	m a ( ' a ) h o n a	m a ( ʔ a ) h o n a	hona	hona	h o n a	737	h o n a	grwd.: hona
 1174	507	M	zekere pisangsoort	certain pisang species	mahamè		mahamE	m a h a m E	m a h a m ɛ						
-1175	507	M	vreemd; een ander, anders, onderscheiden, onderscheid; geenszins	strange; another, different, distinct, differentiation; by no means	mahona(q)	418	mahona(')	m a h o n a ( ' )	m a h o n a ( ʔ )						
+1175	507	M	vreemd ; een ander , anders , onderscheiden , onderscheid ; geenszins	strange ; another , different , distinct , differentiation ; by no means	mahona(q)	418	mahona(')	m a h o n a ( ' )	m a h o n a ( ʔ )						
 1176	507	M	feest bij sterfgevallen	celebration of deaths	maonè		maonE	m a o n E	m a o n ɛ						
-1177	507	M	wasschen, reinigen	washing, cleaning	mĕnokie	420	mėnoki	m ė n o k i	m ə n o k i						
-1178	507	M	ver, verte	far, far	miemie		mimi	m i m i	m i m i						
+1177	507	M	wasschen , reinigen	washing , cleaning	mĕnokie	420	mėnoki	m ė n o k i	m ə n o k i						
+1178	507	M	ver , verte	far , far	miemie		mimi	m i m i	m i m i						
 1179	507	M	zeer ver	very far	miemiena		mimina	m i m i n a	m i m i n a						
-1180	507	M	vinger	finger	miena; mienaoe(w)apo	415	mina; minau(w)apo	m i n a ; # m i n a u ( w ) a p o	m i n a ; # m i n a u ( w ) a p o						
-1181	507	M	toon	tone, or show	mienaoe(w)aie	414	minau(w)ai	m i n a u ( w ) a i	m i n a u ( w ) a i						
-1182	507	M	(mal.), olie	(mal.), oil	mienjaq		miña'	m i ñ a '	m i ɲ a ʔ						malay
+1180	507	M	vinger	finger	miena	415	mina	m i n a	m i n a						
+1180	507	M	vinger	finger	mienaoe(w)apo	415	minau(w)apo	m i n a u ( w ) a p o	m i n a u ( w ) a p o						
+1181	507	M	toon	tone , or show	mienaoe(w)aie	414	minau(w)ai	m i n a u ( w ) a i	m i n a u ( w ) a i						
+1182	507	M	(mal.) , olie	(mal.) , oil	mienjaq		miña'	m i ñ a '	m i ɲ a ʔ						malay
 1183	507	M	bez. vnmwd. van den tweeden persoon	possessive pronoun for the second person	moe		mu	m u	m u						
 1184	507	M	zekere bamboesoort	certain bamboo species	mohoie		mohoi	m o h o i	m o h o i						
-1185	507	M	alle, allerlei	all, miscellaneous	mohomohoiena	417	mohomohoina	m o h o m o h o i n a	m o h o m o h o i n a						
-1186	507	M	wachten, toeven, verbeiden	wait, linger, wait	mokie	439	moki	m o k i	m o k i						
-1187	507	M	veel, hoeveelheid	much, amount	moko		moko	m o k o	m o k o						
-1188	507	M	duur, hoog in prijs	expensive, high in price	moko èodie die(j)a	419	moko Eodi di(y)a	m o k o # E o d i # d i ( y ) a	m o k o # ɛ o d i # d i ( j ) a						
-1189	507	M	die, dat	which, that	moö		mo'o	m o ' o	m o ʔ o						
-1190	507	N	bij zich hebben, dragen, mede of wegdragen, meenemen, wegbrengen	to carry, carry, carry with or away, take with, take away	naäie(j)aha		na'ai(y)aha	n a ' a i ( y ) a h a	n a ʔ a i ( j ) a h a						
+1185	507	M	alle , allerlei	all , miscellaneous	mohomohoiena	417	mohomohoina	m o h o m o h o i n a	m o h o m o h o i n a						
+1186	507	M	wachten , toeven , verbeiden	wait , linger , wait	mokie	439	moki	m o k i	m o k i						
+1187	507	M	veel , hoeveelheid	much , amount	moko		moko	m o k o	m o k o						
+1188	507	M	duur , hoog in prijs	expensive , high in price	moko_èodie_die(j)a	419	moko_Eodi_di(y)a	m o k o _ E o d i _ d i ( y ) a	m o k o _ ɛ o d i _ d i ( j ) a						
+1189	507	M	die , dat	which , that	moö		mo'o	m o ' o	m o ʔ o						
+1190	507	N	bij zich hebben , dragen , mede of wegdragen , meenemen , wegbrengen	to carry , carry , carry with or away , take with , take away	naäie(j)aha		na'ai(y)aha	n a ' a i ( y ) a h a	n a ʔ a i ( j ) a h a						
 1191	508	N	voorouders	ancestors	naäpoe(w)aka(q)	421	na'apu(w)aka(')	n a ' a p u ( w ) a k a ( ' )	n a ʔ a p u ( w ) a k a ( ʔ )						
-1192	508	N	aanstonds, eenmaal, in het vervolg, wachten, iets afwachten, ergens op wachten, een oogenblik	right away, once, in the future, waiting, waiting for something, waiting for something, an instant	naèhapè	422	naEhapE	n a E h a p E	n a ɛ h a p ɛ						
+1192	508	N	aanstonds , eenmaal , in het vervolg , wachten , iets afwachten , ergens op wachten , een oogenblik	right away , once , in the future , waiting , waiting for something , waiting for something , an instant	naèhapè	422	naEhapE	n a E h a p E	n a ɛ h a p ɛ						
 1193	508	N	gezegd van iemand die een zijner bloedverwanten door den dood heeft verloren	said of one who has lost a blood relative through death	nahaja		nahaya	n a h a y a	n a h a j a						
 1194	508	N	schoonouders van de vrouw	wife's parents-in-law	naienaie		nainai	n a i n a i	n a i n a i	amanaie	amanai	a m a n a i	42	a m a n a i	
-1195	508	N	morgen, den volgenden morgen	tomorrow, the following morning	naoemana		naumana	n a u m a n a	n a u m a n a						
-1196	508	N	ijdel, tevergeefs, kosteloos	vain, vain, gratuitous	naponaq	423	napona'	n a p o n a '	n a p o n a ʔ						
-1197	508	N	aannemen, ontvangen	accept, receive	naqä		na'a	n a ' a	n a ʔ a						
+1195	508	N	morgen , den volgenden morgen	tomorrow , the following morning	naoemana		naumana	n a u m a n a	n a u m a n a						
+1196	508	N	ijdel , tevergeefs , kosteloos	vain , vain , gratuitous	naponaq	423	napona'	n a p o n a '	n a p o n a ʔ						
+1197	508	N	aannemen , ontvangen	accept , receive	naqä		na'a	n a ' a	n a ʔ a						
 1198	508	N	medebrengen	bring along	naqie(j)aie		na'i(y)ai	n a ' i ( y ) a i	n a ʔ i ( j ) a i						
-1199	508	N	zoo even, onlangs	just now, recently	nèènie	424	nEEni	n E E n i	n ɛ ɛ n i						
-1200	508	N	verscheurd, aan stukken gescheurd	torn, torn to pieces	nènèka		nEnEka	n E n E k a	n ɛ n ɛ k a						
-1201	508	N			nie(j)a	425	ni(y)a	n i ( y ) a	n i ( j ) a	die(j)a; die(j)ĕ	di(y)a; di(y)ė	d i ( y ) a ; # d i ( y ) ė	w1_96 ; w2_NA	d i ( j ) a ; # d i ( j ) ə	
-1202	508	N	inham, baai	cove, bay	nie(j)oöhieniea	426	ni(y)o'ohinia	n i ( y ) o ' o h i n i a	n i ( j ) o ʔ o h i n i a						
-1203	508	N	zooals dat	such as that	noaha; kienoaha	322	noaha; kinoaha	n o a h a ; # k i n o a h a	n o a h a ; # k i n o a h a						
-1204	508	N	kunnen, mogen, krijgen	can, may, get	noahaq		noaha'	n o a h a '	n o a h a ʔ						
-1205	508	N	schuins, omlaag, zooals eene flesch terwijl er uit geschonken wordt	angled, downwards, like a flask while pouring from it	noèaäq		nua'a'	n u a ' a '	n u a ʔ a ʔ						
-1206	508	N	vragen, navraag doen	ask, enquire	noenohoie	427	nunohoi	n u n o h o i	n u n o h o i						
-1207	508	N	toelaten, laten begaan, laat het geschieden of zijn	allow it, let it happen or be	noha		noha	n o h a	n o h a						
+1199	508	N	zoo even , onlangs	just now , recently	nèènie	424	nEEni	n E E n i	n ɛ ɛ n i						
+1200	508	N	verscheurd , aan stukken gescheurd	torn , torn to pieces	nènèka		nEnEka	n E n E k a	n ɛ n ɛ k a						
+1201	508	N			nie(j)a	425	ni(y)a	n i ( y ) a	n i ( j ) a	die(j)a	di(y)a	d i ( y ) a	96	d i ( j ) a	
+1201	508	N			nie(j)a	425	ni(y)a	n i ( y ) a	n i ( j ) a	die(j)ĕ	di(y)ė	d i ( y ) ė	NA	d i ( j ) ə	
+1202	508	N	inham , baai	cove , bay	nie(j)oöhieniea	426	ni(y)o'ohinia	n i ( y ) o ' o h i n i a	n i ( j ) o ʔ o h i n i a						
+1203	508	N	zooals dat	such as that	noaha	322	noaha	n o a h a	n o a h a						
+1203	508	N	zooals dat	such as that	kienoaha	322	kinoaha	k i n o a h a	k i n o a h a						
+1204	508	N	kunnen , mogen , krijgen	can , may , get	noahaq		noaha'	n o a h a '	n o a h a ʔ						
+1205	508	N	schuins , omlaag , zooals eene flesch terwijl er uit geschonken wordt	angled , downwards , like a flask while pouring from it	noèaäq		nua'a'	n u a ' a '	n u a ʔ a ʔ						
+1206	508	N	vragen , navraag doen	ask , enquire	noenohoie	427	nunohoi	n u n o h o i	n u n o h o i						
+1207	508	N	toelaten , laten begaan , laat het geschieden of zijn	allow it , let it happen or be	noha		noha	n o h a	n o h a						
 1208	508	N	klein	small	nokie		noki	n o k i	n o k i						
-1209	508	N	nieuw, pas, eerst	new, recently, first	noöienĕ		no'oinė	n o ' o i n ė	n o ʔ o i n ə						
-1210	508	N	tegenwoordig, nu	today, now	noönie		no'oni	n o ' o n i	n o ʔ o n i						
+1209	508	N	nieuw , pas , eerst	new , recently , first	noöienĕ		no'oinė	n o ' o i n ė	n o ʔ o i n ə						
+1210	508	N	tegenwoordig , nu	today , now	noönie		no'oni	n o ' o n i	n o ʔ o n i						
 1211	508	N	zooals dit	such as this	no(q)o(q)ie		no(')o(')i	n o ( ' ) o ( ' ) i	n o ( ʔ ) o ( ʔ ) i						
-1212	508	O	indien, wanneer	if, when	oanoaha		oanoaha	o a n o a h a	o a n o a h a						
-1213	508	O	stoelgang	stool, bowel movements	obieoe(w)oeha		obiu(w)uha	o b i u ( w ) u h a	o b i u ( w ) u h a						
-1214	508	O	wegleggen, bewaren, opruimen	put away, store, tidy up	ödaq		u̇da'	u̇ d a '	ɨ d a ʔ						
-1215	508	O	een korten weg nemen, een omweg afsnijden	taking a shortcut, cutting off a diversion	odokie	441	odoki	o d o k i	o d o k i						
-1216	508	O	van, vanaf	of, from	oe		u	u	u						
-1217	508	O	op den grond neerzetten, neerleggen, plaatsen	on the ground, put down, place	oedaq		uda'	u d a '	u d a ʔ						
+1212	508	O	indien , wanneer	if , when	oanoaha		oanoaha	o a n o a h a	o a n o a h a						
+1213	508	O	stoelgang	stool , bowel movements	obieoe(w)oeha		obiu(w)uha	o b i u ( w ) u h a	o b i u ( w ) u h a						
+1214	508	O	wegleggen , bewaren , opruimen	put away , store , tidy up	ödaq		u̇da'	u̇ d a '	ɨ d a ʔ						
+1215	508	O	een korten weg nemen , een omweg afsnijden	taking a shortcut , cutting off a diversion	odokie	441	odoki	o d o k i	o d o k i						
+1216	508	O	van , vanaf	of , from	oe		u	u	u						
+1217	508	O	op den grond neerzetten , neerleggen , plaatsen	on the ground , put down , place	oedaq		uda'	u d a '	u d a ʔ						
 1218	508	O	elleboog	elbow	oekèèpa	436	ukEEpa	u k E E p a	u k ɛ ɛ p a						
-1219	508	O	proef, de proef nemen, beproeven	test, take the test, try	oekiedopè	438	ukidopE	u k i d o p E	u k i d o p ɛ						
-1220	508	O	bepraten, vleien	talk, flatter	oemahaie		umahai	u m a h a i	u m a h a i						
-1221	508	O	of... of; ik weet het niet	or... or; I don't know	oemahaoe		umahau	u m a h a u	u m a h a u						
-1222	508	O	het haar knippen, scheeren	cutting hair, shaving	oenèqie		unE'i	u n E ' i	u n ɛ ʔ i						
-1223	508	O	vouw, gevouwen	fold, folded	oeniekaq		unika'	u n i k a '	u n i k a ʔ						
+1219	508	O	proef , de proef nemen , beproeven	test , take the test , try	oekiedopè	438	ukidopE	u k i d o p E	u k i d o p ɛ						
+1220	508	O	bepraten , vleien	talk , flatter	oemahaie		umahai	u m a h a i	u m a h a i						
+1221	508	O	of... of ; ik weet het niet	or... or ; I don't know	oemahaoe		umahau	u m a h a u	u m a h a u						
+1222	508	O	het haar knippen , scheeren	cutting hair , shaving	oenèqie		unE'i	u n E ' i	u n ɛ ʔ i						
+1223	508	O	vouw , gevouwen	fold , folded	oeniekaq		unika'	u n i k a '	u n i k a ʔ						
 1224	508	O	doove kool	dead cabbage	oeöbie	442	u'obi	u ' o b i	u ʔ o b i						
-1225	509	O	stompen, vuistslagen geven	punching, punching	oeoe		u'u	u ' u	u ʔ u						
+1225	509	O	stompen , vuistslagen geven	punching , punching	oeoe		u'u	u ' u	u ʔ u						
 1226	509	O	likken	lick	oepanie	431	upani	u p a n i	u p a n i						
-1227	509	O	betalen van iets, voldoen	pay for something, satisfy	oepè	432	upE	u p E	u p ɛ						
-1228	509	O	verdragen, dragen, op zich nemen	endure, bear, take on	oepĕhöjaäq	433	upėhu̇ya'a'	u p ė h u̇ y a ' a '	u p ə h ɨ j a ʔ a ʔ						
+1227	509	O	betalen van iets , voldoen	pay for something , satisfy	oepè	432	upE	u p E	u p ɛ						
+1228	509	O	verdragen , dragen , op zich nemen	endure , bear , take on	oepĕhöjaäq	433	upėhu̇ya'a'	u p ė h u̇ y a ' a '	u p ə h ɨ j a ʔ a ʔ						
 1229	509	O	grootouders	grandparents	oepoena(ie)	434	upuna(i)	u p u n a ( i )	u p u n a ( i )						
 1230	509	O	ik	I	oe(w)a	429	u(w)a	u ( w ) a	u ( w ) a						
-1231	509	O	voorbijgaan, voorbij, gepasseerd	pass by, past, passed	oe(w)aha		u(w)aha	u ( w ) a h a	u ( w ) a h a						
+1231	509	O	voorbijgaan , voorbij , gepasseerd	pass by , past , passed	oe(w)aha		u(w)aha	u ( w ) a h a	u ( w ) a h a						
 1232	509	O	eene ficussoort	a ficus species	oewĕoewĕ		uwėuwė	u w ė u w ė	u w ə u w ə						
 1233	509	O	zooveel mogelijk	as much/many as possibe	okaie		okai	o k a i	o k a i						
 1234	509	O	uittrekken van iets dat ergens in of om bevestigd is	pulling out something fixed in or around something	okie		oki	o k i	o k i						
 1235	509	O	urineeren	urinate	omiekoaqaha		omikoa'aha	o m i k o a ' a h a	o m i k o a ʔ a h a						
-1236	509	O	ophouden, omhooghouden, om iets op te vangen	hold up, hold up, to catch something	omö		omu̇	o m u̇	o m ɨ						
-1237	509	O	pers. vrnwd. van den 2en persoon; gijlieden	personal pronoun of the second person; you (plural)	öö		u̇u̇	u̇ u̇	ɨ ɨ						
-1238	509	O	op weg afwachten van iemand, in hinderlaag liggen	waiting for someone on the way, lying in ambush	oödokie	440	o'odoki	o ' o d o k i	o ʔ o d o k i						
+1236	509	O	ophouden , omhooghouden , om iets op te vangen	hold up , hold up , to catch something	omö		omu̇	o m u̇	o m ɨ						
+1237	509	O	pers. vrnwd. van den 2en persoon ; gijlieden	personal pronoun of the second person ; you (plural)	öö		u̇u̇	u̇ u̇	ɨ ɨ						
+1238	509	O	op weg afwachten van iemand , in hinderlaag liggen	waiting for someone on the way , lying in ambush	oödokie	440	o'odoki	o ' o d o k i	o ʔ o d o k i						
 1239	509	O	slachten van een dier	slaughter of an animal	oökie(?)		o'oki(?)	o ' o k i ( ? )	o ʔ o k i ( ? )						
 1240	509	O	soekoe (stam)	suku (tribe)	opahie(j)aka		opahi(y)aka	o p a h i ( y ) a k a	o p a h i ( j ) a k a						
 1241	509	O	wurgen	strangle	opèkaäq		opEka'a'	o p E k a ' a '	o p ɛ k a ʔ a ʔ						
-1242	509	O	met iets puntigs krabben, graven of peuteren	scratching, digging or picking with something pointed	opo		opo	o p o	o p o						
+1242	509	O	met iets puntigs krabben , graven of peuteren	scratching , digging or picking with something pointed	opo		opo	o p o	o p o						
 1243	509	O	komen	come	owahie		owahi	o w a h i	o w a h i						
-1244	509	P	bezoeken, op bezoek gaan	visiting, going to visit	paämahaie	234	pa'amahai	p a ' a m a h a i	p a ʔ a m a h a i						
+1244	509	P	bezoeken , op bezoek gaan	visiting , going to visit	paämahaie	234	pa'amahai	p a ' a m a h a i	p a ʔ a m a h a i						
 1245	509	P	opzetten van eene woning	setting up a dwelling	pabèoe		pabEu	p a b E u	p a b ɛ u						
-1246	509	P	vermengd, ondereengemengd	mixed, unmixed	paboedajaq	235	pabudaya'	p a b u d a y a '	p a b u d a j a ʔ						
-1247	509	P	gaar, rijp	done, ripe	paböha	236	pabu̇ha	p a b u̇ h a	p a b ɨ h a	paha böhaq	paha bu̇ha'	p a h a # b u̇ h a '	1262	p a h a # b ɨ h a ʔ	v.g.l.: paha böhaq
-1248	509	P	huwelijk, huwen	marriage, marrying	padahèboe(w)a	237	padahEbu(w)a	p a d a h E b u ( w ) a	p a d a h ɛ b u ( w ) a						
-1249	509	P	hangen, opgehangen zijn aan iets	hanging, being suspended from something	padaiejaäq		padaiya'a'	p a d a i y a ' a '	p a d a i j a ʔ a ʔ						
-1250	509	P	verward, door elkander, dooreengemengd	confused, mixed up, intermingled	padiehoie(j)aqä	260	padihoi(y)a'a	p a d i h o i ( y ) a ' a	p a d i ç o i ( j ) a ʔ a						
-1251	509	P	bedaard, zacht, stilletjes, langzaam	subdued, gentle, quiet, slow	padiehopie	259	padihopi	p a d i h o p i	p a d i ç o p i						
-1252	509	P	tegenpartij, tegenstander	counterparty, opponent	padiekaä	261	padika'a	p a d i k a ' a	p a d i k a ʔ a						
+1246	509	P	vermengd , ondereengemengd	mixed , unmixed	paboedajaq	235	pabudaya'	p a b u d a y a '	p a b u d a j a ʔ						
+1247	509	P	gaar , rijp	done , ripe	paböha	236	pabu̇ha	p a b u̇ h a	p a b ɨ h a	paha böhaq	paha bu̇ha'	p a h a # b u̇ h a '	1262	p a h a # b ɨ h a ʔ	v.g.l.: paha böhaq
+1248	509	P	huwelijk , huwen	marriage , marrying	padahèboe(w)a	237	padahEbu(w)a	p a d a h E b u ( w ) a	p a d a h ɛ b u ( w ) a						
+1249	509	P	hangen , opgehangen zijn aan iets	hanging , being suspended from something	padaiejaäq		padaiya'a'	p a d a i y a ' a '	p a d a i j a ʔ a ʔ						
+1250	509	P	verward , door elkander , dooreengemengd	confused , mixed up , intermingled	padiehoie(j)aqä	260	padihoi(y)a'a	p a d i h o i ( y ) a ' a	p a d i ç o i ( j ) a ʔ a						
+1251	509	P	bedaard , zacht , stilletjes , langzaam	subdued , gentle , quiet , slow	padiehopie	259	padihopi	p a d i h o p i	p a d i ç o p i						
+1252	509	P	tegenpartij , tegenstander	counterparty , opponent	padiekaä	261	padika'a	p a d i k a ' a	p a d i k a ʔ a						
 1253	509	P	bij elkander verzameld	gathered together	padoedoie		padudoi	p a d u d o i	p a d u d o i						
 1254	509	P	het benoodigd materiaal voor het tot stand brengen van een of ander	the material required to create one or other	padoewaä		paduwa'a	p a d u w a ' a	p a d u w a ʔ a						
-1255	509	P	hangen, opgehangen zijn aan iets	hanging, being suspended from something	paèdoha	443	paEdoha	p a E d o h a	p a ɛ d o h a						
-1256	509	P	bloedverwant (?)	blood relative (?)	paèhie		paEhi	p a E h i	p a ɛ h i						
-1257	509	P	verhuizen, naar eene andere plaats overbrengen, verplaatsen	move, transfer to another place, relocate	paèho		paEho	p a E h o	p a ɛ h o						
-1258	510	P	overspel bedrijven, buitenechtelijke gemeenschap, minnehandel hebben	commit adultery, have extra-marital intercourse, engage in minstrelsy	paèie		paEi	p a E i	p a ɛ i						
+1255	509	P	hangen , opgehangen zijn aan iets	hanging , being suspended from something	paèdoha	443	paEdoha	p a E d o h a	p a ɛ d o h a						
+1256	509	P	bloedverwant ( ? )	blood relative ( ? )	paèhie		paEhi	p a E h i	p a ɛ h i						
+1257	509	P	verhuizen , naar eene andere plaats overbrengen , verplaatsen	move , transfer to another place , relocate	paèho		paEho	p a E h o	p a ɛ h o						
+1258	510	P	overspel bedrijven , buitenechtelijke gemeenschap , minnehandel hebben	commit adultery , have extra-marital intercourse , engage in minstrelsy	paèie		paEi	p a E i	p a ɛ i						
 1259	510	P	opzetten van eene woning	setting up a dwelling	paènoe		paEnu	p a E n u	p a ɛ n u						
 1260	510	P	om het eerst trachten te bemachtigen ; met zijn velen wedijveren om iets meester te worden	to try to get it first ; competing with many to become master of something	pahabieaäq	444	pahabia'a'	p a h a b i a ' a '	p a h a b i a ʔ a ʔ						
-1261	510	P	streng, kluwen	strand, tangle	pahaboe(w)ĕ		pahabu(w)ė	p a h a b u ( w ) ė	p a h a b u ( w ) ə						
-1262	510	P	gaar, rijp, koken, gaar maken	cooked, ripe, boiling, cooking	pa(ha)böhaq	233	pa(ha)bu̇ha'	p a ( h a ) b u̇ h a '	p a ( h a ) b ɨ h a ʔ						
-1263	510	P	vergelden, beantwoorden, vergoeden, weeromgeven	to retaliate, to answer, to compensate, to return	pahadodie(j)aäq		pahadodi(y)a'a'	p a h a d o d i ( y ) a ' a '	p a h a d o d i ( j ) a ʔ a ʔ						
-1264	510	P	schuldgevoel, berouw	guilt, repentance	pahadoho; pahadoho èkiedjaie(j)oe	241	pahadoho; pahadoho Ekijai(y)u	p a h a d o h o ; # p a h a d o h o # E k i j a i ( y ) u	p a h a d o h o ; # p a h a d o h o # ɛ k i d͡ʒ a i ( j ) u						
+1261	510	P	streng , kluwen	strand , tangle	pahaboe(w)ĕ		pahabu(w)ė	p a h a b u ( w ) ė	p a h a b u ( w ) ə						
+1262	510	P	gaar , rijp , koken , gaar maken	cooked , ripe , boiling , cooking	pa(ha)böhaq	233	pa(ha)bu̇ha'	p a ( h a ) b u̇ h a '	p a ( h a ) b ɨ h a ʔ						
+1263	510	P	vergelden , beantwoorden , vergoeden , weeromgeven	to retaliate , to answer , to compensate , to return	pahadodie(j)aäq		pahadodi(y)a'a'	p a h a d o d i ( y ) a ' a '	p a h a d o d i ( j ) a ʔ a ʔ						
+1264	510	P	schuldgevoel , berouw	guilt , repentance	pahadoho	241	pahadoho	p a h a d o h o	p a h a d o h o						
+1264	510	P	schuldgevoel , berouw	guilt , repentance	pahadoho_èkiedjaie(j)oe	241	pahadoho_Ekijai(y)u	p a h a d o h o _ E k i j a i ( y ) u	p a h a d o h o _ ɛ k i d͡ʒ a i ( j ) u						
 1265	510	P	te vuur zetten om te koken	set fire to cook	pahaèkoe		pahaEku	p a h a E k u	p a h a ɛ k u						
 1266	510	P	het feest gegeven bij het te water laten van een sampan	the party given at the launch of a sampan	pahakè(j)aq		pahakE(y)a'	p a h a k E ( y ) a '	p a h a k ɛ ( j ) a ʔ						
-1267	510	P	rots, gesteente	rock, stone	pahakie(j)a	445	pahaki(y)a	p a h a k i ( y ) a	p a h a k i ( j ) a						
-1268	510	P	vast, standvastig, bestendig	firm, steadfast, resistant	pahakoienanaq		pahakoinana'	p a h a k o i n a n a '	p a h a k o i n a n a ʔ						
+1267	510	P	rots , gesteente	rock , stone	pahakie(j)a	445	pahaki(y)a	p a h a k i ( y ) a	p a h a k i ( j ) a						
+1268	510	P	vast , standvastig , bestendig	firm , steadfast , resistant	pahakoienanaq		pahakoinana'	p a h a k o i n a n a '	p a h a k o i n a n a ʔ						
 1269	510	P	de korte redevoering gehouden bij het «kaléak(oe)baba» feest	The short speech delivered at the “kaléak(oe)baba” celebration	pahaö		paha'o	p a h a ' o	p a h a ʔ o						
-1270	510	P	in bedwang houden, beletten	restrain, prevent	pahapèaq		pahapEa'	p a h a p E a '	p a h a p ɛ a ʔ						
-1271	510	P	voltooid, klaar, gereed; ook: verzameld, bijeen	completed, finished, ready; also: gathered, assembled	pahapoeè(q)	240	pahapuE(')	p a h a p u E ( ' )	p a h a p u ɛ ( ʔ )						
-1272	510	P	het van plaats veranderen, zich verplaatsen	changing place, moving around	pahjo	242	pahyo	p a h y o	p a h j o						
+1270	510	P	in bedwang houden , beletten	restrain , prevent	pahapèaq		pahapEa'	p a h a p E a '	p a h a p ɛ a ʔ						
+1271	510	P	voltooid , klaar , gereed ; ook : verzameld , bijeen	completed , finished , ready ; also : gathered , assembled	pahapoeè(q)	240	pahapuE(')	p a h a p u E ( ' )	p a h a p u ɛ ( ʔ )						
+1272	510	P	het van plaats veranderen , zich verplaatsen	changing place , moving around	pahjo	242	pahyo	p a h y o	p a h j o						
 1273	510	P	staart	tail	pahodaie		pahodai	p a h o d a i	p a h o d a i						
-1274	510	P	rollen, voortrollen	rolling, rolling forward	pahoehoedoe	243	pahuhudu	p a h u h u d u	p a h u h u d u						
+1274	510	P	rollen , voortrollen	rolling , rolling forward	pahoehoedoe	243	pahuhudu	p a h u h u d u	p a h u h u d u						
 1275	510	P	± 6 u. in den morgen	± 6 am in the morning	pahoemana		pahumana	p a h u m a n a	p a h u m a n a						
 1276	510	P	soekoe (stam)	suku (tribe)	pahoeoenaq		pahu'una'	p a h u ' u n a '	p a h u ʔ u n a ʔ						
 1277	510	P	met de vuist of knokkels stooten inz. op het hoofd en het gelaat	hitting with fist or knuckles e.g. on head and face	pahoqoekie		paho'uki	p a h o ' u k i	p a h o ʔ u k i						
 1278	510	P	den bijslaap uitoefenen	have sexual intercourse	pahoraie		pahorai	p a h o r a i	p a h o r a i						
-1279	510	P	regelen, rangschikken, in orde brengen	arrange, arrange, put in order	paienènèaq	244	painEnEa'	p a i n E n E a '	p a i n ɛ n ɛ a ʔ						
+1279	510	P	regelen , rangschikken , in orde brengen	arrange , arrange , put in order	paienènèaq	244	painEnEa'	p a i n E n E a '	p a i n ɛ n ɛ a ʔ						
 1280	510	P	dooden van levende wezens	killing of living beings	pakahadè	454	pakahadE	p a k a h a d E	p a k a h a d ɛ						
-1281	510	P	omhelzen, in de armen houden	embrace, hold in your arms	pakahopa	245	pakahopa	p a k a h o p a	p a k a h o p a						
-1282	510	P	onder eene massa herkennen, kennis maken het uit elkander kennen	recognise among a mass, meet, recognise each other	pakaö(w)aq		paka'o(w)a'	p a k a ' o ( w ) a '	p a k a ʔ o ( w ) a ʔ						
-1283	510	P	overdwars	across, sideways	pakarahaq	246	pakaraha'	p a k a r a h a '	p a k a r a h a ʔ						
-1284	510	P	verbieden, tegengaan, verboden zijn	prohibit, counteract, be prohibited	pakèho(w)oq		pakEho(w)o'	p a k E h o ( w ) o '	p a k ɛ h o ( w ) o ʔ						
+1281	510	P	omhelzen , in de armen houden	embrace , hold in your arms	pakahopa	245	pakahopa	p a k a h o p a	p a k a h o p a						
+1282	510	P	onder eene massa herkennen , kennis maken het uit elkander kennen	recognise among a mass , meet , recognise each other	pakaö(w)aq		paka'o(w)a'	p a k a ' o ( w ) a '	p a k a ʔ o ( w ) a ʔ						
+1283	510	P	overdwars	across , sideways	pakarahaq	246	pakaraha'	p a k a r a h a '	p a k a r a h a ʔ						
+1284	510	P	verbieden , tegengaan , verboden zijn	prohibit , counteract , be prohibited	pakèho(w)oq		pakEho(w)o'	p a k E h o ( w ) o '	p a k ɛ h o ( w ) o ʔ						
 1285	510	P	iets wat men ergens opplakt	something one sticks on something	pakè(j)aq		pakE(y)a'	p a k E ( y ) a '	p a k ɛ ( j ) a ʔ						
-1286	510	P	ruilen, verwisselen	exchange, swap	pakèlie(j)a	247	pakEli(y)a	p a k E l i ( y ) a	p a k ɛ l i ( j ) a						
-1287	511	P	verborgen, verscholen	hidden, tucked away	pakie(j)oe		paki(y)u	p a k i ( y ) u	p a k i ( j ) u						
+1286	510	P	ruilen , verwisselen	exchange , swap	pakèlie(j)a	247	pakEli(y)a	p a k E l i ( y ) a	p a k ɛ l i ( j ) a						
+1287	511	P	verborgen , verscholen	hidden , tucked away	pakie(j)oe		paki(y)u	p a k i ( y ) u	p a k i ( j ) u						
 1288	511	P	tegen iets slaan of stooten	hit or bump into something	pakiemaha		pakimaha	p a k i m a h a	p a k i m a h a						
-1289	511	P	wedijveren, wie het sterkste is	compete, who is the strongest	pakieno		pakino	p a k i n o	p a k i n o						
+1289	511	P	wedijveren , wie het sterkste is	compete , who is the strongest	pakieno		pakino	p a k i n o	p a k i n o						
 1290	511	P	plat op den buik liggen	lie flat on your stomach	pakieopo	446	pakiopo	p a k i o p o	p a k i o p o						
-1291	511	P	achterna komen, iemand achternaloopen om hem in te halen	chasing, running after someone to catch up with them	pakoba		pakoba	p a k o b a	p a k o b a						
-1292	511	P	paal, stijl, mast	pole, style, mast	pakoehè	249	pakuhE	p a k u h E	p a k u h ɛ						
-1293	511	P	roeren, omroeren	stirring, stirring	pakoehie(j)aq	447	pakuhi(y)a'	p a k u h i ( y ) a '	p a k u h i ( j ) a ʔ						
-1294	511	P	aaneengehecht, samengelascht, aangezet, verlengd	joined, welded together, dilated, extended	pakoehö(j)aq	250	pakuhu̇(y)a'	p a k u h u̇ ( y ) a '	p a k u h ɨ ( j ) a ʔ						
-1295	511	P	vertrouwen stellen, vertrouwen, lichtgeloovig	trust, confidence, credulous	pakoeienanaq		pakuinana'	p a k u i n a n a '	p a k u i n a n a ʔ						
-1296	511	P	leeren	leather, or learn	pakoenaq		pakuna'	p a k u n a '	p a k u n a ʔ						
-1297	511	P	onbeschoft, lomp	rude, boorish	kèo pakoenaq aiekiedjaieboe	336	kEo pakuna' aikijaibu	k E o # p a k u n a ' # a i k i j a i b u	k ɛ o # p a k u n a ʔ # a i k i d͡ʒ a i b u						
-1298	511	P	uitslag, vurigheid in het gezicht	rash, burning in the face	pakoenoejo		pakunuyo	p a k u n u y o	p a k u n u j o						
-1299	511	P	gooien, weggooien, werpen, smakken, smijten	throw, discard, throw, smack, smash	pakoeoe(w)aq	448	paku'u(w)a'	p a k u ' u ( w ) a '	p a k u ʔ u ( w ) a ʔ						
-1300	511	P	geschil, verschil	dispute, difference	pakoepèq	248	pakupE'	p a k u p E '	p a k u p ɛ ʔ						
-1301	511	P	bevel, last	order, charge	pakoe(w)aq		paku(w)a'	p a k u ( w ) a '	p a k u ( w ) a ʔ						
-1302	511	P	verkrijgen, erlangen	obtain, desire	pakohaq		pakoha'	p a k o h a '	p a k o h a ʔ						
-1303	511	P	in bezit genomen, gekregen worden, gevangen genomen	taken possession of, received, captured	pako(q)öhaäq		pako(')u̇ha'a'	p a k o ( ' ) u̇ h a ' a '	p a k o ( ʔ ) ɨ h a ʔ a ʔ						
+1291	511	P	achterna komen , iemand achternaloopen om hem in te halen	chasing , running after someone to catch up with them	pakoba		pakoba	p a k o b a	p a k o b a						
+1292	511	P	paal , stijl , mast	pole , style , mast	pakoehè	249	pakuhE	p a k u h E	p a k u h ɛ						
+1293	511	P	roeren , omroeren	stirring , stirring	pakoehie(j)aq	447	pakuhi(y)a'	p a k u h i ( y ) a '	p a k u h i ( j ) a ʔ						
+1294	511	P	aaneengehecht , samengelascht , aangezet , verlengd	joined , welded together , dilated , extended	pakoehö(j)aq	250	pakuhu̇(y)a'	p a k u h u̇ ( y ) a '	p a k u h ɨ ( j ) a ʔ						
+1295	511	P	vertrouwen stellen , vertrouwen , lichtgeloovig	trust , confidence , credulous	pakoeienanaq		pakuinana'	p a k u i n a n a '	p a k u i n a n a ʔ						
+1296	511	P	leeren	leather , or learn	pakoenaq		pakuna'	p a k u n a '	p a k u n a ʔ						
+1297	511	P	onbeschoft , lomp	rude , boorish	kèo_pakoenaq_aiekiedjaieboe	336	kEo_pakuna'_aikijaibu	k E o _ p a k u n a ' _ a i k i j a i b u	k ɛ o _ p a k u n a ʔ _ a i k i d͡ʒ a i b u						
+1298	511	P	uitslag , vurigheid in het gezicht	rash , burning in the face	pakoenoejo		pakunuyo	p a k u n u y o	p a k u n u j o						
+1299	511	P	gooien , weggooien , werpen , smakken , smijten	throw , discard , throw , smack , smash	pakoeoe(w)aq	448	paku'u(w)a'	p a k u ' u ( w ) a '	p a k u ʔ u ( w ) a ʔ						
+1300	511	P	geschil , verschil	dispute , difference	pakoepèq	248	pakupE'	p a k u p E '	p a k u p ɛ ʔ						
+1301	511	P	bevel , last	order , charge	pakoe(w)aq		paku(w)a'	p a k u ( w ) a '	p a k u ( w ) a ʔ						
+1302	511	P	verkrijgen , erlangen	obtain , desire	pakohaq		pakoha'	p a k o h a '	p a k o h a ʔ						
+1303	511	P	in bezit genomen , gekregen worden , gevangen genomen	taken possession of , received , captured	pako(q)öhaäq		pako(')u̇ha'a'	p a k o ( ' ) u̇ h a ' a '	p a k o ( ʔ ) ɨ h a ʔ a ʔ						
 1304	511	P	hinken	limping	pako(w)èhko(w)èh		pako(w)Ehko(w)Eh	p a k o ( w ) E h k o ( w ) E h	p a k o ( w ) ɛ h k o ( w ) ɛ h						
-1305	511	P	duister, avond	darkness, evening	pamahaoema	449	pamahauma	p a m a h a u m a	p a m a h a u m a						
-1306	511	P	anders worden, veranderen	becoming different, changing	pamahona	284	pamahona	p a m a h o n a	p a m a h o n a						
+1305	511	P	duister , avond	darkness , evening	pamahaoema	449	pamahauma	p a m a h a u m a	p a m a h a u m a						
+1306	511	P	anders worden , veranderen	becoming different , changing	pamahona	284	pamahona	p a m a h o n a	p a m a h o n a						
 1307	511	P	de tong uitsteken	sticking the tongue out	pamèmèho		pamEmEho	p a m E m E h o	p a m ɛ m ɛ h o						
-1308	511	P	schudden, iets of ergens aan schudden	shaking, shaking something or anything	pana(h)	252	pana(h)	p a n a ( h )	p a n a ( h )						
-1309	511	P	juist, juist van pas, toereikend, genoegzaam, voldoende, reeds, toereikend, vol, voltallig, in zijn geheel	right, just of fit, adequate, sufficient, sufficient, already, adequate, full, complete, in its entirety	panako	253	panako	p a n a k o	p a n a k o						
-1310	511	P	gelijk, gelijk zijn, gelijk in waarde	equal, being equal in value	panakona	254	panakona	p a n a k o n a	p a n a k o n a						
-1311	511	P	zonder wederga	without equal	kie(j)abaq panakona	331	ki(y)aba' panakona	k i ( y ) a b a ' # p a n a k o n a	k i ( j ) a b a ʔ # p a n a k o n a						
-1312	511	P	evenbeeld, wederga	likeness, equal	panakonaäq	255	panakona'a'	p a n a k o n a ' a '	p a n a k o n a ʔ a ʔ						
-1313	511	P	aanspreken, toespreken	address, address	panaoe	256	panau	p a n a u	p a n a u						
-1314	511	P	uitspannen, uitspreiden	stretch out, spread out	panapa		panapa	p a n a p a	p a n a p a						
-1315	511	P	op een korten afstand, dichtbij	at a short distance, close by	panè	257	panE	p a n E	p a n ɛ						
-1316	511	P	genaderd, bijna, nabij	approached, almost, near	hopanè	273	hopanE	h o p a n E	h o p a n ɛ						
-1317	511	P	bedrog, list, streek	deception, trick, prank	panènèhaie		panEnEhai	p a n E n E h a i	p a n ɛ n ɛ h a i						
-1318	511	P	spoedig, schielijk, gauw, snel, haast, spoed	quickly, quickly, quickly, quickly, hurry, rush	panieha(q)	450	paniha(')	p a n i h a ( ' )	p a n i ç a ( ʔ )						
-1319	511	P	overal in het rond, rondom in het rond	all around, all around	paodèaq		paodEa'	p a o d E a '	p a o d ɛ a ʔ						
-1320	512	P	ergens wegleggen, weggelegd hebben om het te bewaren, plaatsen, neerzetten	put away somewhere, put away to keep it, place, put down	paoeho(q)		pauho(')	p a u h o ( ' )	p a u h o ( ʔ )						
+1308	511	P	schudden , iets of ergens aan schudden	shaking , shaking something or anything	pana(h)	252	pana(h)	p a n a ( h )	p a n a ( h )						
+1309	511	P	juist , juist van pas , toereikend , genoegzaam , voldoende , reeds , toereikend , vol , voltallig , in zijn geheel	right , just of fit , adequate , sufficient , sufficient , already , adequate , full , complete , in its entirety	panako	253	panako	p a n a k o	p a n a k o						
+1310	511	P	gelijk , gelijk zijn , gelijk in waarde	equal , being equal in value	panakona	254	panakona	p a n a k o n a	p a n a k o n a						
+1311	511	P	zonder wederga	without equal	kie(j)abaq_panakona	331	ki(y)aba'_panakona	k i ( y ) a b a ' _ p a n a k o n a	k i ( j ) a b a ʔ _ p a n a k o n a						
+1312	511	P	evenbeeld , wederga	likeness , equal	panakonaäq	255	panakona'a'	p a n a k o n a ' a '	p a n a k o n a ʔ a ʔ						
+1313	511	P	aanspreken , toespreken	address , address	panaoe	256	panau	p a n a u	p a n a u						
+1314	511	P	uitspannen , uitspreiden	stretch out , spread out	panapa		panapa	p a n a p a	p a n a p a						
+1315	511	P	op een korten afstand , dichtbij	at a short distance , close by	panè	257	panE	p a n E	p a n ɛ						
+1316	511	P	genaderd , bijna , nabij	approached , almost , near	hopanè	273	hopanE	h o p a n E	h o p a n ɛ						
+1317	511	P	bedrog , list , streek	deception , trick , prank	panènèhaie		panEnEhai	p a n E n E h a i	p a n ɛ n ɛ h a i						
+1318	511	P	spoedig , schielijk , gauw , snel , haast , spoed	quickly , quickly , quickly , quickly , hurry , rush	panieha(q)	450	paniha(')	p a n i h a ( ' )	p a n i ç a ( ʔ )						
+1319	511	P	overal in het rond , rondom in het rond	all around , all around	paodèaq		paodEa'	p a o d E a '	p a o d ɛ a ʔ						
+1320	512	P	ergens wegleggen , weggelegd hebben om het te bewaren , plaatsen , neerzetten	put away somewhere , put away to keep it , place , put down	paoeho(q)		pauho(')	p a u h o ( ' )	p a u h o ( ʔ )						
 1321	512	P	woordentwist bijleggen	settle word strife	paoe(w)a	451	pau(w)a	p a u ( w ) a	p a u ( w ) a						
-1322	512	P	schudden, iets of ergens aan schudden	shaking, shaking something or anything	paoe(w)aoe		pau(w)au	p a u ( w ) a u	p a u ( w ) a u						
-1323	512	P	in geregelde volgorde op, in of naast elkander geplaatste, bij elkander behoorende voorwerpen ; stapel, stel	placed in regular order on, in or next to each other, belonging to each other ; stack, set	paopajaäq	258	paopaya'a'	p a o p a y a ' a '	p a o p a j a ʔ a ʔ						
+1322	512	P	schudden , iets of ergens aan schudden	shaking , shaking something or anything	paoe(w)aoe		pau(w)au	p a u ( w ) a u	p a u ( w ) a u						
+1323	512	P	in geregelde volgorde op , in of naast elkander geplaatste , bij elkander behoorende voorwerpen ; stapel , stel	placed in regular order on , in or next to each other , belonging to each other ; stack , set	paopajaäq	258	paopaya'a'	p a o p a y a ' a '	p a o p a j a ʔ a ʔ						
 1324	512	P	plooi	fold	paopèkie(j)aq		paopEki(y)a'	p a o p E k i ( y ) a '	p a o p ɛ k i ( j ) a ʔ						
 1325	512	P	wang	cheek	papa	238	papa	p a p a	p a p a						
-1326	512	P	sprong, het springen	jump, jumping	papĕrabie		papėrabi	p a p ė r a b i	p a p ə r a b i						
-1327	512	P	hellend, scheef	sloping, oblique	papèa	239	papEa	p a p E a	p a p ɛ a						
+1326	512	P	sprong , het springen	jump , jumping	papĕrabie		papėrabi	p a p ė r a b i	p a p ə r a b i						
+1327	512	P	hellend , scheef	sloping , oblique	papèa	239	papEa	p a p E a	p a p ɛ a						
 1328	512	P	geraas en getier makend	ranting and raving	papèhodie		papEhodi	p a p E h o d i	p a p ɛ h o d i						
-1329	512	P	vechten, plukharen	fighting, bickering	papoedoe	452	papudu	p a p u d u	p a p u d u	èpoedoe	Epudu	E p u d u	671	ɛ p u d u	grwd. èpoedoe?
-1330	512	P	stampen, aanstampen	mashing, stamping	paqjo		pa'yo	p a ' y o	p a ʔ j o						
-1331	512	P	stap, schrede	step, stride	parabie		parabi	p a r a b i	p a r a b i						
-1332	512	P	loeren, bespieden, beloeren	lurking, spying, watching	parahoeie		parahui	p a r a h u i	p a r a h u i						
+1329	512	P	vechten , plukharen	fighting , bickering	papoedoe	452	papudu	p a p u d u	p a p u d u	èpoedoe	Epudu	E p u d u	671	ɛ p u d u	grwd. èpoedoe?
+1330	512	P	stampen , aanstampen	mashing , stamping	paqjo		pa'yo	p a ' y o	p a ʔ j o						
+1331	512	P	stap , schrede	step , stride	parabie		parabi	p a r a b i	p a r a b i						
+1332	512	P	loeren , bespieden , beloeren	lurking , spying , watching	parahoeie		parahui	p a r a h u i	p a r a h u i						
 1333	512	P	in gezelschap van	in the company of	parako(w)a		parako(w)a	p a r a k o ( w ) a	p a r a k o ( w ) a						
-1334	512	P	verward, door elkander, dooreengemengd	confused, mixed up, intermingled	pariehoie(j)aqä	251	parihoi(y)a'a	p a r i h o i ( y ) a ' a	p a r i ç o i ( j ) a ʔ a						
+1334	512	P	verward , door elkander , dooreengemengd	confused , mixed up , intermingled	pariehoie(j)aqä	251	parihoi(y)a'a	p a r i h o i ( y ) a ' a	p a r i ç o i ( j ) a ʔ a						
 1335	512	P	zekere boomsoort met deugdzaam timmerhout	certain tree species with decent lumber	pariepoepoeh		paripupuh	p a r i p u p u h	p a r i p u p u h						
-1336	512	P	doen maken, vervaardigen	make, manufacture	parieqö	262	pari'u̇	p a r i ' u̇	p a r i ʔ ɨ						
-1337	512	P	vermengd, dooreengemengd, ondereengemengd	mixed, intermixed, mixed	paroepèie	263	parupEi	p a r u p E i	p a r u p ɛ i						
+1336	512	P	doen maken , vervaardigen	make , manufacture	parieqö	262	pari'u̇	p a r i ' u̇	p a r i ʔ ɨ						
+1337	512	P	vermengd , dooreengemengd , ondereengemengd	mixed , intermixed , mixed	paroepèie	263	parupEi	p a r u p E i	p a r u p ɛ i						
 1338	512	P	12 u. ’s middags	12 noon	paroähaja		paro'ahaya	p a r o ' a h a y a	p a r o ʔ a h a j a						
 1339	512	P	zekere pisangsoort	certain banana species	parobiekie		parobiki	p a r o b i k i	p a r o b i k i						
-1340	512	P	baard, sik	beard, goatee	paroriepo	264	paroripo	p a r o r i p o	p a r o r i p o						
-1341	512	P	aangeven, aanreiken, overgeven	indicate, hand over, surrender	pè	453	pE	p E	p ɛ						
-1342	512	P	aan iemand geven, aan een ander geven	give to someone, give to another	haboepè		habupE	h a b u p E	h a b u p ɛ						
+1340	512	P	baard , sik	beard , goatee	paroriepo	264	paroripo	p a r o r i p o	p a r o r i p o						
+1341	512	P	aangeven , aanreiken , overgeven	indicate , hand over , surrender	pè	453	pE	p E	p ɛ						
+1342	512	P	aan iemand geven , aan een ander geven	give to someone , give to another	haboepè		habupE	h a b u p E	h a b u p ɛ						
 1343	512	P	zenden van zaken	sending of cases	pè(j)aha	265	pE(y)aha	p E ( y ) a h a	p ɛ ( j ) a h a						
-1344	512	P	gespannen, strak	tense, tight	pĕkaka		pėkaka	p ė k a k a	p ə k a k a						
+1344	512	P	gespannen , strak	tense , tight	pĕkaka		pėkaka	p ė k a k a	p ə k a k a						
 1345	512	P	in de rondte draaien	whirl	pĕkakarie(j)aq		pėkakari(y)a'	p ė k a k a r i ( y ) a '	p ə k a k a r i ( j ) a ʔ						
-1346	512	P	te leen, wat teruggegeven moet worden, te leen vragen, leenen van iemand	to borrow, what must be returned, ask to borrow, borrow from someone	pènjako	457	pEñako	p E ñ a k o	p ɛ ɲ a k o						
-1347	512	P	begeerig, belust	covetous, eager	pènohie(j)o	266	pEnohi(y)o	p E n o h i ( y ) o	p ɛ n o h i ( j ) o						
-1348	512	P	wrijven, knijpen, zacht tusschen de vingers knijpen, zacht drukken van de ledematen	rubbing, pinching, gently squeezing between the fingers, gentle pressing of the limbs	piehie	267	pihi	p i h i	p i ç i						
+1346	512	P	te leen , wat teruggegeven moet worden , te leen vragen , leenen van iemand	to borrow , what must be returned , ask to borrow , borrow from someone	pènjako	457	pEñako	p E ñ a k o	p ɛ ɲ a k o						
+1347	512	P	begeerig , belust	covetous , eager	pènohie(j)o	266	pEnohi(y)o	p E n o h i ( y ) o	p ɛ n o h i ( j ) o						
+1348	512	P	wrijven , knijpen , zacht tusschen de vingers knijpen , zacht drukken van de ledematen	rubbing , pinching , gently squeezing between the fingers , gentle pressing of the limbs	piehie	267	pihi	p i h i	p i ç i						
 1349	512	P	zekere pisangsoort	certain banana species	pie(j)ako(w)èq		pi(y)ako(w)E'	p i ( y ) a k o ( w ) E '	p i ( j ) a k o ( w ) ɛ ʔ						
 1350	512	P	uitkloppen van kleedingstukken	beating of garments	piekie(j)aq		piki(y)a'	p i k i ( y ) a '	p i k i ( j ) a ʔ						
 1351	512	P	eene liaansoort	a liana species	piekopieko		pikopiko	p i k o p i k o	p i k o p i k o						
 1352	513	P	bijten van menschen en dieren	biting humans and animals	piekoöie		piko'oi	p i k o ' o i	p i k o ʔ o i						
-1353	513	P	zich omkeeren, omdraaien in den slaap	turning around, turning over in sleep	pienahaäq	456	pinaha'a'	p i n a h a ' a '	p i n a h a ʔ a ʔ						
-1354	513	P	pak, bundel	pack, bundle	pieöhaäq		pi'oha'a'	p i ' o h a ' a '	p i ʔ o h a ʔ a ʔ						
-1355	513	P	gezien kunnen worden, te zien zijn, zichtbaar zijn	be seen, be seen, be visible	piepienaq		pipina'	p i p i n a '	p i p i n a ʔ						
+1353	513	P	zich omkeeren , omdraaien in den slaap	turning around , turning over in sleep	pienahaäq	456	pinaha'a'	p i n a h a ' a '	p i n a h a ʔ a ʔ						
+1354	513	P	pak , bundel	pack , bundle	pieöhaäq		pi'oha'a'	p i ' o h a ' a '	p i ʔ o h a ʔ a ʔ						
+1355	513	P	gezien kunnen worden , te zien zijn , zichtbaar zijn	be seen , be seen , be visible	piepienaq		pipina'	p i p i n a '	p i p i n a ʔ						
 1356	513	P	in water afkooken	boil in water	poedaq		puda'	p u d a '	p u d a ʔ						
 1357	513	P	borstvin der visschen	pectoral fin of fish	poedarie		pudari	p u d a r i	p u d a r i	èpoedarie	Epudari	E p u d a r i	670	ɛ p u d a r i	
-1358	513	P	open en bloot, openen	open and exposed, opening	poekoie		pukoi	p u k o i	p u k o i						
-1359	513	P	samenverbonden zooals een rist uien, bladeren van een tak, vruchten aan een steel	bound together like a row of onions, leaves on a branch, fruits on a stem	poeoenjaq		pu'uña'	p u ' u ñ a '	p u ʔ u ɲ a ʔ						
-1360	513	P	iemand kwaad doen, woedend moorden, alles overhoop steken wat men ontmoet (v.g.l.: papoedoe)	to harm someone, to kill in fury, to stab everything one comes across (c.f.: papudu)	poepoedoe	459	pupudu	p u p u d u	p u p u d u	papoedoe	papudu	p a p u d u	1329	p a p u d u	
-1361	513	P	vluchten, wegloopen, hard loopen	flee, run away, run fast	poeqä		pu'a	p u ' a	p u ʔ a						
+1358	513	P	open en bloot , openen	open and exposed , opening	poekoie		pukoi	p u k o i	p u k o i						
+1359	513	P	samenverbonden zooals een rist uien , bladeren van een tak , vruchten aan een steel	bound together like a row of onions , leaves on a branch , fruits on a stem	poeoenjaq		pu'uña'	p u ' u ñ a '	p u ʔ u ɲ a ʔ						
+1360	513	P	iemand kwaad doen , woedend moorden , alles overhoop steken wat men ontmoet (v.g.l. : papoedoe)	to harm someone , to kill in fury , to stab everything one comes across (c.f. : papudu)	poepoedoe	459	pupudu	p u p u d u	p u p u d u	papoedoe	papudu	p a p u d u	1329	p a p u d u	
+1361	513	P	vluchten , wegloopen , hard loopen	flee , run away , run fast	poeqä		pu'a	p u ' a	p u ʔ a						
 1362	513	P	weduwnaar	widower	poerieho	458	puriho	p u r i h o	p u r i ç o						
 1363	513	P	mogen	may	pohaie		pohai	p o h a i	p o h a i						
-1364	513	P	denk er over na, bedenk wel	think about it, remember	pohoie(j)aoda		pohoi(y)aoda	p o h o i ( y ) a o d a	p o h o i ( j ) a o d a						
-1365	513	P	gedachte, nadenken, overdenken	thought, ponder, contemplate	pöhöjaq		pu̇hu̇ya'	p u̇ h u̇ y a '	p ɨ h ɨ j a ʔ						
-1366	513	P	verbeelding, voorstelling, waan	imagination, representation, delusion	pöhöjaq		pu̇hu̇ya'	p u̇ h u̇ y a '	p ɨ h ɨ j a ʔ						
-1367	513	P	leugenachtig, leugen	lying, lie	poporo	268	poporo	p o p o r o	p o p o r o						
-1368	513	P	vouw, gevouwen	fold, folded	poöpèkie(j)aq		po'opEki(y)a'	p o ' o p E k i ( y ) a '	p o ʔ o p ɛ k i ( j ) a ʔ						
-1369	513	R	(mal.), hoofd	(mal.), head	radjo		rajo	r a j o	r a d͡ʒ o						malay
-1370	513	R	(mal.), terechtzitting, rechtbank	(mal.), hearing, court	rapat		rapat	r a p a t	r a p a t						malay
-1371	513	T	twintig; een term, die de hoeveelheid te ruilen goed aangeeft, destijds in gebruik bij de bepaling van de ruilwaarde van diverse goederen (de waarde kwam overeen met 20 centen); een gewicht overeenkomende met ± 5 katis gewicht	twenty; a term, indicating the quantity of good to be exchanged, in use at the time in determining the exchange value of various goods (the value corresponded to 20 cents); a weight corresponding to ± 5 katis weight	taka		taka	t a k a	t a k a						
-1372	513	T	(mal.), ring	(Mal.), ring	tjientjien		cincin	c i n c i n	t͡ʃ i n t͡ʃ i n						malay
-1373	513	W	benauwd, beklemd, aamborstig	craped, constricted, asthmatic	wakiepörö	461	wakipu̇ru̇	w a k i p u̇ r u̇	w a k i p ɨ r ɨ						
-1374	513	count terms	een	one, a	(è)kahaèq	3	(E)kahaE'	( E ) k a h a E '	( ɛ ) k a h a ɛ ʔ						
+1364	513	P	denk er over na , bedenk wel	think about it , remember	pohoie(j)aoda		pohoi(y)aoda	p o h o i ( y ) a o d a	p o h o i ( j ) a o d a						
+1365	513	P	gedachte , nadenken , overdenken	thought , ponder , contemplate	pöhöjaq		pu̇hu̇ya'	p u̇ h u̇ y a '	p ɨ h ɨ j a ʔ						
+1366	513	P	verbeelding , voorstelling , waan	imagination , representation , delusion	pöhöjaq		pu̇hu̇ya'	p u̇ h u̇ y a '	p ɨ h ɨ j a ʔ						
+1367	513	P	leugenachtig , leugen	lying , lie	poporo	268	poporo	p o p o r o	p o p o r o						
+1368	513	P	vouw , gevouwen	fold , folded	poöpèkie(j)aq		po'opEki(y)a'	p o ' o p E k i ( y ) a '	p o ʔ o p ɛ k i ( j ) a ʔ						
+1369	513	R	(mal.) , hoofd	(mal.) , head	radjo		rajo	r a j o	r a d͡ʒ o						malay
+1370	513	R	(mal.) , terechtzitting , rechtbank	(mal.) , hearing , court	rapat		rapat	r a p a t	r a p a t						malay
+1371	513	T	twintig ; een term , die de hoeveelheid te ruilen goed aangeeft , destijds in gebruik bij de bepaling van de ruilwaarde van diverse goederen (de waarde kwam overeen met 20 centen) ; een gewicht overeenkomende met ± 5 katis gewicht	twenty ; a term , indicating the quantity of good to be exchanged , in use at the time in determining the exchange value of various goods (the value corresponded to 20 cents) ; a weight corresponding to ± 5 katis weight	taka		taka	t a k a	t a k a						
+1372	513	T	(mal.) , ring	(Mal.) , ring	tjientjien		cincin	c i n c i n	t͡ʃ i n t͡ʃ i n						malay
+1373	513	W	benauwd , beklemd , aamborstig	craped , constricted , asthmatic	wakiepörö	461	wakipu̇ru̇	w a k i p u̇ r u̇	w a k i p ɨ r ɨ						
+1374	513	count terms	een	one , a	(è)kahaèq	3	(E)kahaE'	( E ) k a h a E '	( ɛ ) k a h a ɛ ʔ						
 1375	513	count terms	twee	two	adoe(w)a	51	adu(w)a	a d u ( w ) a	a d u ( w ) a						
 1376	514	count terms	drie	three	akoloe		akolu	a k o l u	a k o l u						
 1377	514	count terms	vier	four	a(o)pa	11	a(o)pa	a ( o ) p a	a ( o ) p a						
 1378	514	count terms	vijf	five	adieba	47	adiba	a d i b a	a d i b a						
 1379	514	count terms	zes	six	akieäkiena	30	aki'akina	a k i ' a k i n a	a k i ʔ a k i n a						
-1380	514	count terms	zeven	seven	adieba hie adoe(w)a		adiba hi adu(w)a	a d i b a # h i # a d u ( w ) a	a d i b a # h i # a d u ( w ) a						
-1381	514	count terms	zeven	seven	arieba hie aroe(w)a		ariba hi aru(w)a	a r i b a # h i # a r u ( w ) a	a r i b a # h i # a r u ( w ) a						
-1382	514	count terms	zeven	seven	aliebĕ hie adoe(w)ĕ		alibė hi adu(w)ė	a l i b ė # h i # a d u ( w ) ė	a l i b ə # h i # a d u ( w ) ə						
-1383	514	count terms	acht	eight	a(o)pa hie a(o)pa	12	a(o)pa hi a(o)pa	a ( o ) p a # h i # a ( o ) p a	a ( o ) p a # h i # a ( o ) p a						
+1380	514	count terms	zeven	seven	adieba_hie_adoe(w)a		adiba_hi_adu(w)a	a d i b a _ h i _ a d u ( w ) a	a d i b a _ h i _ a d u ( w ) a						
+1381	514	count terms	zeven	seven	arieba_hie_aroe(w)a		ariba_hi_aru(w)a	a r i b a _ h i _ a r u ( w ) a	a r i b a _ h i _ a r u ( w ) a						
+1382	514	count terms	zeven	seven	aliebĕ_hie_adoe(w)ĕ		alibė_hi_adu(w)ė	a l i b ė _ h i _ a d u ( w ) ė	a l i b ə _ h i _ a d u ( w ) ə						
+1383	514	count terms	acht	eight	a(o)pa_hie_a(o)pa	12	a(o)pa_hi_a(o)pa	a ( o ) p a _ h i _ a ( o ) p a	a ( o ) p a _ h i _ a ( o ) p a						
 1384	514	count terms	negen	nine	abaiekahaèq	17	abaikahaE'	a b a i k a h a E '	a b a i k a h a ɛ ʔ						
 1385	514	count terms	tien	ten	kiepa(a)oeq	346	kipa(a)u'	k i p a ( a ) u '	k i p a ( a ) u ʔ						
-1386	514	count terms	elf	eleven	kiepa(a)oeq hie (è)kahaèq	347	kipa(a)u' hi (E)kahaE'	k i p a ( a ) u ' # h i # ( E ) k a h a E '	k i p a ( a ) u ʔ # h i # ( ɛ ) k a h a ɛ ʔ						
-1387	514	count terms	twaalf	twelve	kiepa(a)oeq hie adoe(w)a	348	kipa(a)u' hi adu(w)a	k i p a ( a ) u ' # h i # a d u ( w ) a	k i p a ( a ) u ʔ # h i # a d u ( w ) a						enz. (eng: etc.)
-1388	514	count terms	twaalf	twelve	kiepa(a)oeq hie aroe(w)a	350	kipa(a)u' hi aru(w)a	k i p a ( a ) u ' # h i # a r u ( w ) a	k i p a ( a ) u ʔ # h i # a r u ( w ) a						enz. (eng: etc.)
-1389	514	count terms	twaalf	twelve	kiepa(a)oeq hie adoe(w)ĕ	349	kipa(a)u' hi adu(w)ė	k i p a ( a ) u ' # h i # a d u ( w ) ė	k i p a ( a ) u ʔ # h i # a d u ( w ) ə						enz. (eng: etc.)
-1390	514	count terms	twintig	twenty	(è)kahaèq taka	5	(E)kahaE' taka	( E ) k a h a E ' # t a k a	( ɛ ) k a h a ɛ ʔ # t a k a						
-1391	514	count terms	een en twintig	twenty-one	(è)kahaèq taka hie (è)kahaèq	6	(E)kahaE' taka hi (E)kahaE'	( E ) k a h a E ' # t a k a # h i # ( E ) k a h a E '	( ɛ ) k a h a ɛ ʔ # t a k a # h i # ( ɛ ) k a h a ɛ ʔ						enz. (eng: etc.)
-1392	514	count terms	dertig	thirty	(è)kahaèq taka hie kiepa(a)oeq	1	(E)kahaE' taka hi kipa(a)u'	( E ) k a h a E ' # t a k a # h i # k i p a ( a ) u '	( ɛ ) k a h a ɛ ʔ # t a k a # h i # k i p a ( a ) u ʔ						
-1393	514	count terms	een en dertig	thirty-one	(è)kahaèq taka hie kiepa(a)oeq, hie (è)kahaèq	7	(E)kahaE' taka hi kipa(a)u', hi (E)kahaE'	( E ) k a h a E ' # t a k a # h i # k i p a ( a ) u ' , # h i # ( E ) k a h a E '	( ɛ ) k a h a ɛ ʔ # t a k a # h i # k i p a ( a ) u ʔ , # h i # ( ɛ ) k a h a ɛ ʔ						enz. (eng: etc.)
-1394	514	count terms	veertig	forty	adoe(w)a taka		adu(w)a taka	a d u ( w ) a # t a k a	a d u ( w ) a # t a k a						
-1395	514	count terms	veertig	forty	aroe(w)a taka		aru(w)a taka	a r u ( w ) a # t a k a	a r u ( w ) a # t a k a						
-1396	514	count terms	veertig	forty	adoe(w)ĕ taka		adu(w)ė taka	a d u ( w ) ė # t a k a	a d u ( w ) ə # t a k a						
-1397	514	count terms	een en veertig	forty-one	adoe(w)a taka hie (è)kahaèq	20	adu(w)a taka hi (E)kahaE'	a d u ( w ) a # t a k a # h i # ( E ) k a h a E '	a d u ( w ) a # t a k a # h i # ( ɛ ) k a h a ɛ ʔ						enz. (eng: etc.)
-1398	514	count terms	een en veertig	forty-one	aroe(w)a taka hie (è)kahaèq	48	aru(w)a taka hi (E)kahaE'	a r u ( w ) a # t a k a # h i # ( E ) k a h a E '	a r u ( w ) a # t a k a # h i # ( ɛ ) k a h a ɛ ʔ						enz. (eng: etc.)
-1399	514	count terms	een en veertig	forty-one	adoe(w)ĕ taka hie (è)kahaèq	22	adu(w)ė taka hi (E)kahaE'	a d u ( w ) ė # t a k a # h i # ( E ) k a h a E '	a d u ( w ) ə # t a k a # h i # ( ɛ ) k a h a ɛ ʔ						enz. (eng: etc.)
-1400	514	count terms	vijftig	fifty	adoe(w)a taka hie kiepa(a)oeq	21	adu(w)a taka hi kipa(a)u'	a d u ( w ) a # t a k a # h i # k i p a ( a ) u '	a d u ( w ) a # t a k a # h i # k i p a ( a ) u ʔ						
-1401	514	count terms	vijftig	fifty	aroe(w)a taka hie kiepa(a)oeq	49	aru(w)a taka hi kipa(a)u'	a r u ( w ) a # t a k a # h i # k i p a ( a ) u '	a r u ( w ) a # t a k a # h i # k i p a ( a ) u ʔ						
-1402	514	count terms	vijftig	fifty	adoe(w)ĕ taka hie kiepa(a)oeq	23	adu(w)ė taka hi kipa(a)u'	a d u ( w ) ė # t a k a # h i # k i p a ( a ) u '	a d u ( w ) ə # t a k a # h i # k i p a ( a ) u ʔ						
-1403	514	count terms	zestig	sixty	akaloe taka		akalu taka	a k a l u # t a k a	a k a l u # t a k a						
-1404	514	count terms	zeventig	seventy	akoloe taka hie kiepa(a)oeq	33	akolu taka hi kipa(a)u'	a k o l u # t a k a # h i # k i p a ( a ) u '	a k o l u # t a k a # h i # k i p a ( a ) u ʔ						
-1405	514	count terms	tachtig	eighty	a(o)pa taka		a(o)pa taka	a ( o ) p a # t a k a	a ( o ) p a # t a k a						
-1406	514	count terms	tachtig	eighty	a(o)fa taka		a(o)fa taka	a ( o ) f a # t a k a	a ( o ) f a # t a k a						
-1407	514	count terms	negentig	ninety	a(o)pa taka hie kiepa(a)oeq	15	a(o)pa taka hi kipa(a)u'	a ( o ) p a # t a k a # h i # k i p a ( a ) u '	a ( o ) p a # t a k a # h i # k i p a ( a ) u ʔ						
-1408	514	count terms	negentig	ninety	a(o)fa taka hie kiepa(a)oeq	13	a(o)fa taka hi kipa(a)u'	a ( o ) f a # t a k a # h i # k i p a ( a ) u '	a ( o ) f a # t a k a # h i # k i p a ( a ) u ʔ						
-1409	515	count terms	honderd	one hundred	adieba taka		adiba taka	a d i b a # t a k a	a d i b a # t a k a						
-1410	515	count terms	honderd	one hundred	arieba taka		ariba taka	a r i b a # t a k a	a r i b a # t a k a						
-1411	515	count terms	honderd	one hundred	aliebĕ taka		alibė taka	a l i b ė # t a k a	a l i b ə # t a k a						
-1412	515	count terms	tweehonderd	two hundred	kiepa(a)oeq taka		kipa(a)u' taka	k i p a ( a ) u ' # t a k a	k i p a ( a ) u ʔ # t a k a						
-1413	515	count terms	tweehonderd	two hundred	kiefa(a)oeq taka		kifa(a)u' taka	k i f a ( a ) u ' # t a k a	k i f a ( a ) u ʔ # t a k a						
-1414	515	count terms	vier honderd	four hundred	(è)kahaèq koedodoka	4	(E)kahaE' kudodoka	( E ) k a h a E ' # k u d o d o k a	( ɛ ) k a h a ɛ ʔ # k u d o d o k a						elke toon en vinger voor een “taka” gerekend (eng: every tone and finger counted for a “taka”)
+1386	514	count terms	elf	eleven	kiepa(a)oeq_hie_(è)kahaèq	347	kipa(a)u'_hi_(E)kahaE'	k i p a ( a ) u ' _ h i _ ( E ) k a h a E '	k i p a ( a ) u ʔ _ h i _ ( ɛ ) k a h a ɛ ʔ						
+1387	514	count terms	twaalf	twelve	kiepa(a)oeq_hie_adoe(w)a	348	kipa(a)u'_hi_adu(w)a	k i p a ( a ) u ' _ h i _ a d u ( w ) a	k i p a ( a ) u ʔ _ h i _ a d u ( w ) a						enz. (eng: etc.)
+1388	514	count terms	twaalf	twelve	kiepa(a)oeq_hie_aroe(w)a	350	kipa(a)u'_hi_aru(w)a	k i p a ( a ) u ' _ h i _ a r u ( w ) a	k i p a ( a ) u ʔ _ h i _ a r u ( w ) a						enz. (eng: etc.)
+1389	514	count terms	twaalf	twelve	kiepa(a)oeq_hie_adoe(w)ĕ	349	kipa(a)u'_hi_adu(w)ė	k i p a ( a ) u ' _ h i _ a d u ( w ) ė	k i p a ( a ) u ʔ _ h i _ a d u ( w ) ə						enz. (eng: etc.)
+1390	514	count terms	twintig	twenty	(è)kahaèq_taka	5	(E)kahaE'_taka	( E ) k a h a E ' _ t a k a	( ɛ ) k a h a ɛ ʔ _ t a k a						
+1391	514	count terms	een en twintig	twenty-one	(è)kahaèq_taka_hie_(è)kahaèq	6	(E)kahaE'_taka_hi_(E)kahaE'	( E ) k a h a E ' _ t a k a _ h i _ ( E ) k a h a E '	( ɛ ) k a h a ɛ ʔ _ t a k a _ h i _ ( ɛ ) k a h a ɛ ʔ						enz. (eng: etc.)
+1392	514	count terms	dertig	thirty	(è)kahaèq_taka_hie_kiepa(a)oeq	1	(E)kahaE'_taka_hi_kipa(a)u'	( E ) k a h a E ' _ t a k a _ h i _ k i p a ( a ) u '	( ɛ ) k a h a ɛ ʔ _ t a k a _ h i _ k i p a ( a ) u ʔ						
+1393	514	count terms	een en dertig	thirty-one	(è)kahaèq_taka_hie_kiepa(a)oeq,_hie_(è)kahaèq	7	(E)kahaE'_taka_hi_kipa(a)u',_hi_(E)kahaE'	( E ) k a h a E ' _ t a k a _ h i _ k i p a ( a ) u ' , _ h i _ ( E ) k a h a E '	( ɛ ) k a h a ɛ ʔ _ t a k a _ h i _ k i p a ( a ) u ʔ , _ h i _ ( ɛ ) k a h a ɛ ʔ						enz. (eng: etc.)
+1394	514	count terms	veertig	forty	adoe(w)a_taka		adu(w)a_taka	a d u ( w ) a _ t a k a	a d u ( w ) a _ t a k a						
+1395	514	count terms	veertig	forty	aroe(w)a_taka		aru(w)a_taka	a r u ( w ) a _ t a k a	a r u ( w ) a _ t a k a						
+1396	514	count terms	veertig	forty	adoe(w)ĕ_taka		adu(w)ė_taka	a d u ( w ) ė _ t a k a	a d u ( w ) ə _ t a k a						
+1397	514	count terms	een en veertig	forty-one	adoe(w)a_taka_hie_(è)kahaèq	20	adu(w)a_taka_hi_(E)kahaE'	a d u ( w ) a _ t a k a _ h i _ ( E ) k a h a E '	a d u ( w ) a _ t a k a _ h i _ ( ɛ ) k a h a ɛ ʔ						enz. (eng: etc.)
+1398	514	count terms	een en veertig	forty-one	aroe(w)a_taka_hie_(è)kahaèq	48	aru(w)a_taka_hi_(E)kahaE'	a r u ( w ) a _ t a k a _ h i _ ( E ) k a h a E '	a r u ( w ) a _ t a k a _ h i _ ( ɛ ) k a h a ɛ ʔ						enz. (eng: etc.)
+1399	514	count terms	een en veertig	forty-one	adoe(w)ĕ_taka_hie_(è)kahaèq	22	adu(w)ė_taka_hi_(E)kahaE'	a d u ( w ) ė _ t a k a _ h i _ ( E ) k a h a E '	a d u ( w ) ə _ t a k a _ h i _ ( ɛ ) k a h a ɛ ʔ						enz. (eng: etc.)
+1400	514	count terms	vijftig	fifty	adoe(w)a_taka_hie_kiepa(a)oeq	21	adu(w)a_taka_hi_kipa(a)u'	a d u ( w ) a _ t a k a _ h i _ k i p a ( a ) u '	a d u ( w ) a _ t a k a _ h i _ k i p a ( a ) u ʔ						
+1401	514	count terms	vijftig	fifty	aroe(w)a_taka_hie_kiepa(a)oeq	49	aru(w)a_taka_hi_kipa(a)u'	a r u ( w ) a _ t a k a _ h i _ k i p a ( a ) u '	a r u ( w ) a _ t a k a _ h i _ k i p a ( a ) u ʔ						
+1402	514	count terms	vijftig	fifty	adoe(w)ĕ_taka_hie_kiepa(a)oeq	23	adu(w)ė_taka_hi_kipa(a)u'	a d u ( w ) ė _ t a k a _ h i _ k i p a ( a ) u '	a d u ( w ) ə _ t a k a _ h i _ k i p a ( a ) u ʔ						
+1403	514	count terms	zestig	sixty	akaloe_taka		akalu_taka	a k a l u _ t a k a	a k a l u _ t a k a						
+1404	514	count terms	zeventig	seventy	akoloe_taka_hie_kiepa(a)oeq	33	akolu_taka_hi_kipa(a)u'	a k o l u _ t a k a _ h i _ k i p a ( a ) u '	a k o l u _ t a k a _ h i _ k i p a ( a ) u ʔ						
+1405	514	count terms	tachtig	eighty	a(o)pa_taka		a(o)pa_taka	a ( o ) p a _ t a k a	a ( o ) p a _ t a k a						
+1406	514	count terms	tachtig	eighty	a(o)fa_taka		a(o)fa_taka	a ( o ) f a _ t a k a	a ( o ) f a _ t a k a						
+1407	514	count terms	negentig	ninety	a(o)pa_taka_hie_kiepa(a)oeq	15	a(o)pa_taka_hi_kipa(a)u'	a ( o ) p a _ t a k a _ h i _ k i p a ( a ) u '	a ( o ) p a _ t a k a _ h i _ k i p a ( a ) u ʔ						
+1408	514	count terms	negentig	ninety	a(o)fa_taka_hie_kiepa(a)oeq	13	a(o)fa_taka_hi_kipa(a)u'	a ( o ) f a _ t a k a _ h i _ k i p a ( a ) u '	a ( o ) f a _ t a k a _ h i _ k i p a ( a ) u ʔ						
+1409	515	count terms	honderd	one hundred	adieba_taka		adiba_taka	a d i b a _ t a k a	a d i b a _ t a k a						
+1410	515	count terms	honderd	one hundred	arieba_taka		ariba_taka	a r i b a _ t a k a	a r i b a _ t a k a						
+1411	515	count terms	honderd	one hundred	aliebĕ_taka		alibė_taka	a l i b ė _ t a k a	a l i b ə _ t a k a						
+1412	515	count terms	tweehonderd	two hundred	kiepa(a)oeq_taka		kipa(a)u'_taka	k i p a ( a ) u ' _ t a k a	k i p a ( a ) u ʔ _ t a k a						
+1413	515	count terms	tweehonderd	two hundred	kiefa(a)oeq_taka		kifa(a)u'_taka	k i f a ( a ) u ' _ t a k a	k i f a ( a ) u ʔ _ t a k a						
+1414	515	count terms	vier honderd	four hundred	(è)kahaèq_koedodoka	4	(E)kahaE'_kudodoka	( E ) k a h a E ' _ k u d o d o k a	( ɛ ) k a h a ɛ ʔ _ k u d o d o k a						elke toon en vinger voor een “taka” gerekend (eng: every tone and finger counted for a “taka”)

--- a/data/helfrich1916_variant.tsv
+++ b/data/helfrich1916_variant.tsv
@@ -1,13 +1,17 @@
 ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_ipa_segments
 16	2	aäfoe(w)a(q)	a'afu(w)a(')	a ' a f u ( w ) a ( ' )	a ʔ a f u ( w ) a ( ʔ )
 18	4	abaiekahaèq	abaikahaE'	a b a i k a h a E '	a b a i k a h a ɛ ʔ
-19	5	abako(w)a; abako(w)ĕ	abako(w)a; abako(w)ė	a b a k o ( w ) a ; # a b a k o ( w ) ė	a b a k o ( w ) a ; # a b a k o ( w ) ə
+19	5	abako(w)a	abako(w)a	a b a k o ( w ) a	a b a k o ( w ) a
+19	5	abako(w)ĕ	abako(w)ė	a b a k o ( w ) ė	a b a k o ( w ) ə
 460	8	wabèha	wabEha	w a b E h a	w a b ɛ h a
 43	12	arèq	arE'	a r E '	a r ɛ ʔ
 44	13	arie	ari	a r i	a r i
-46	14	arieba; aliebĕ	ariba; alibė	a r i b a ; # a l i b ė	a r i b a ; # a l i b ə
-45	15	arieba hie adoe(w)a; aliebĕ hie adoe(w)ĕ	ariba hi adu(w)a; alibė hi adu(w)ė	a r i b a # h i # a d u ( w ) a ; # a l i b ė # h i # a d u ( w ) ė	a r i b a # h i # a d u ( w ) a ; # a l i b ə # h i # a d u ( w ) ə
-50	17	aroe(w)a; adoe(w)ĕ	aru(w)a; adu(w)ė	a r u ( w ) a ; # a d u ( w ) ė	a r u ( w ) a ; # a d u ( w ) ə
+46	14	arieba	ariba	a r i b a	a r i b a
+46	14	aliebĕ	alibė	a l i b ė	a l i b ə
+45	15	arieba_hie_adoe(w)a	ariba_hi_adu(w)a	a r i b a _ h i _ a d u ( w ) a	a r i b a _ h i _ a d u ( w ) a
+45	15	aliebĕ_hie_adoe(w)ĕ	alibė_hi_adu(w)ė	a l i b ė _ h i _ a d u ( w ) ė	a l i b ə _ h i _ a d u ( w ) ə
+50	17	aroe(w)a	aru(w)a	a r u ( w ) a	a r u ( w ) a
+50	17	adoe(w)ĕ	adu(w)ė	a d u ( w ) ė	a d u ( w ) ə
 25	29	aèkoie	aEkoi	a E k o i	a ɛ k o i
 26	30	aèkoie(j)aq	aEkoi(y)a'	a E k o i ( y ) a '	a ɛ k o i ( j ) a ʔ
 31	32	akieäkienĕ	aki'akinė	a k i ' a k i n ė	a k i ʔ a k i n ə
@@ -16,10 +20,14 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 29	37	akènaie	akEnai	a k E n a i	a k ɛ n a i
 34	39	akoroe	akoru	a k o r u	a k o r u
 73	41	èahèaqja	EahEa'ya	E a h E a ' y a	ɛ a h ɛ a ʔ j a
-36	44	amoeno; moeno; kĕno; koeno	amuno; muno; kėno; kuno	a m u n o ; # m u n o ; # k ė n o ; # k u n o	a m u n o ; # m u n o ; # k ə n o ; # k u n o
+36	44	amoeno	amuno	a m u n o	a m u n o
+36	44	moeno	muno	m u n o	m u n o
+36	44	kĕno	kėno	k ė n o	k ə n o
+36	44	koeno	kuno	k u n o	k u n o
 35	46	amoeafĕ	amuafė	a m u a f ė	a m u a f ə
 37	47	amoho	amoho	a m o h o	a m o h o
-143	49	èkiena; èkienĕ	Ekina; Ekinė	E k i n a ; # E k i n ė	ɛ k i n a ; # ɛ k i n ə
+143	49	èkiena	Ekina	E k i n a	ɛ k i n a
+143	49	èkienĕ	Ekinė	E k i n ė	ɛ k i n ə
 462	51	waniemaie	wanimai	w a n i m a i	w a n i m a i
 40	54	anoqoe	ano'u	a n o ' u	a n o ʔ u
 39	58	anoqè(j)ĕ	ano'E(y)ė	a n o ' E ( y ) ė	a n o ʔ ɛ ( j ) ə
@@ -27,14 +35,18 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 10	61	a(o)fa	a(o)fa	a ( o ) f a	a ( o ) f a
 14	62	a(o)fahiea(o)fa	a(o)fahia(o)fa	a ( o ) f a h i a ( o ) f a	a ( o ) f a h i a ( o ) f a
 52	69	aroekoe(w)o	aruku(w)o	a r u k u ( w ) o	a r u k u ( w ) o
-53	70	aroekoe(w)o è(a)karoba	aruku(w)o E(a)karoba	a r u k u ( w ) o # E ( a ) k a r o b a	a r u k u ( w ) o # ɛ ( a ) k a r o b a
+53	70	aroekoe(w)o_è(a)karoba	aruku(w)o_E(a)karoba	a r u k u ( w ) o _ E ( a ) k a r o b a	a r u k u ( w ) o _ ɛ ( a ) k a r o b a
 54	78	bahabaiebĕ	bahabaibė	b a h a b a i b ė	b a h a b a i b ə
 55	80	baöadie	ba'oadi	b a ' o a d i	b a ʔ o a d i
 56	84	bèdie	bEdi	b E d i	b ɛ d i
 58	92	daiekahadie(j)ĕ	daikahadi(y)ė	d a i k a h a d i ( y ) ė	d a i k a h a d i ( j ) ə
 59	96	die(j)ĕ	di(y)ė	d i ( y ) ė	d i ( j ) ə
-184	105	èoä(h)ko; èaä(h)kĕ; èoähkĕ	Eo'a(h)ko; Ea'a(h)kė; Eo'ahkė	E o ' a ( h ) k o ; # E a ' a ( h ) k ė ; # E o ' a h k ė	ɛ o ʔ a ( h ) k o ; # ɛ a ʔ a ( h ) k ə ; # ɛ o ʔ a h k ə
-416	106	moä(h)ko; maä(h)kĕ; moä(h)kĕ	mo'a(h)ko; ma'a(h)kė; mo'a(h)kė	m o ' a ( h ) k o ; # m a ' a ( h ) k ė ; # m o ' a ( h ) k ė	m o ʔ a ( h ) k o ; # m a ʔ a ( h ) k ə ; # m o ʔ a ( h ) k ə
+184	105	èoä(h)ko	Eo'a(h)ko	E o ' a ( h ) k o	ɛ o ʔ a ( h ) k o
+184	105	èaä(h)kĕ	Ea'a(h)kė	E a ' a ( h ) k ė	ɛ a ʔ a ( h ) k ə
+184	105	èoähkĕ	Eo'ahkė	E o ' a h k ė	ɛ o ʔ a h k ə
+416	106	moä(h)ko	mo'a(h)ko	m o ' a ( h ) k o	m o ʔ a ( h ) k o
+416	106	maä(h)kĕ	ma'a(h)kė	m a ' a ( h ) k ė	m a ʔ a ( h ) k ə
+416	106	moä(h)kĕ	mo'a(h)kė	m o ' a ( h ) k ė	m o ʔ a ( h ) k ə
 65	114	èabarie(j)o	Eabari(y)o	E a b a r i ( y ) o	ɛ a b a r i ( j ) o
 64	115	èabaoekietaie	Eabaukitai	E a b a u k i t a i	ɛ a b a u k i t a i
 72	124	èahabaoedĕ	Eahabaudė	E a h a b a u d ė	ɛ a h a b a u d ə
@@ -52,7 +64,7 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 66	183	èafala	Eafala	E a f a l a	ɛ a f a l a
 69	184	èafĕ	Eafė	E a f ė	ɛ a f ə
 70	185	èafoe	Eafu	E a f u	ɛ a f u
-71	186	èafoe èkoe(w)ĕ	Eafu Eku(w)ė	E a f u # E k u ( w ) ė	ɛ a f u # ɛ k u ( w ) ə
+71	186	èafoe_èkoe(w)ĕ	Eafu_Eku(w)ė	E a f u _ E k u ( w ) ė	ɛ a f u _ ɛ k u ( w ) ə
 172	193	èmanè	EmanE	E m a n E	ɛ m a n ɛ
 9	195	(oe)kiaroboe	(u)kiarobu	( u ) k i a r o b u	( u ) k i a r o b u
 27	198	afĕ	afė	a f ė	a f ə
@@ -60,13 +72,15 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 82	201	èaraä(q)ko(w)ah	Eara'a(')ko(w)ah	E a r a ' a ( ' ) k o ( w ) a h	ɛ a r a ʔ a ( ʔ ) k o ( w ) a h
 78	205	èalopa	Ealopa	E a l o p a	ɛ a l o p a
 83	207	èatara	Eatara	E a t a r a	ɛ a t a r a
-84	215	èbaka: èoewĕ	Ebaka: Euwė	E b a k a : # E u w ė	ɛ b a k a : # ɛ u w ə
+84	215	èbaka:_èoewĕ	Ebaka:_Euwė	E b a k a : _ E u w ė	ɛ b a k a : _ ɛ u w ə
 391	217	kietaie	kitai	k i t a i	k i t a i
 85	226	èboeèparaqwĕ	EbuEpara'wė	E b u E p a r a ' w ė	ɛ b u ɛ p a r a ʔ w ə
 86	228	èboqaboqĕ	Ebo'abo'ė	E b o ' a b o ' ė	ɛ b o ʔ a b o ʔ ə
 160	229	èlaba	Elaba	E l a b a	ɛ l a b a
-230	230	ètaboeho; ètafoehĕ	Etabuho; Etafuhė	E t a b u h o ; # E t a f u h ė	ɛ t a b u h o ; # ɛ t a f u h ə
-231	231	ètaboeho; ètafoehĕ	Etabuho; Etafuhė	E t a b u h o ; # E t a f u h ė	ɛ t a b u h o ; # ɛ t a f u h ə
+230	230	ètaboeho	Etabuho	E t a b u h o	ɛ t a b u h o
+230	230	ètafoehĕ	Etafuhė	E t a f u h ė	ɛ t a f u h ə
+231	231	ètaboeho	Etabuho	E t a b u h o	ɛ t a b u h o
+231	231	ètafoehĕ	Etafuhė	E t a f u h ė	ɛ t a f u h ə
 144	237	èkietaie	Ekitai	E k i t a i	ɛ k i t a i
 193	238	èoeloe	Eulu	E u l u	ɛ u l u
 194	241	èoeloe	Eulu	E u l u	ɛ u l u
@@ -79,18 +93,22 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 165	250	èlie(j)ĕ	Eli(y)ė	E l i ( y ) ė	ɛ l i ( j ) ə
 166	251	èlieie(j)ĕ	Elii(y)ė	E l i i ( y ) ė	ɛ l i i ( j ) ə
 167	257	èloboe	Elobu	E l o b u	ɛ l o b u
-168	258	èloboe kanapoe(w)a	Elobu kanapu(w)a	E l o b u # k a n a p u ( w ) a	ɛ l o b u # k a n a p u ( w ) a
+168	258	èloboe_kanapoe(w)a	Elobu_kanapu(w)a	E l o b u _ k a n a p u ( w ) a	ɛ l o b u _ k a n a p u ( w ) a
 90	259	èdorie	Edori	E d o r i	ɛ d o r i
 228	260	èroehoekie(j)aq	Eruhuki(y)a'	E r u h u k i ( y ) a '	ɛ r u h u k i ( j ) a ʔ
 183	261	ènohaie	Enohai	E n o h a i	ɛ n o h a i
-88	262	èdĕhoie; èdjĕhoie	Edėhoi; Ejėhoi	E d ė h o i ; # E j ė h o i	ɛ d ə h o i ; # ɛ d͡ʒ ə h o i
-342	263	kiedĕhoie; kiedjĕhoie	kidėhoi; kijėhoi	k i d ė h o i ; # k i j ė h o i	k i d ə h o i ; # k i d͡ʒ ə h o i
+88	262	èdĕhoie	Edėhoi	E d ė h o i	ɛ d ə h o i
+88	262	èdjĕhoie	Ejėhoi	E j ė h o i	ɛ d͡ʒ ə h o i
+342	263	kiedĕhoie	kidėhoi	k i d ė h o i	k i d ə h o i
+342	263	kiedjĕhoie	kijėhoi	k i j ė h o i	k i d͡ʒ ə h o i
 170	264	èlolèlolè	ElolElolE	E l o l E l o l E	ɛ l o l ɛ l o l ɛ
-280	267	iedopo; ètofo; ietofo	idopo; Etofo; itofo	i d o p o ; # E t o f o ; # i t o f o	i d o p o ; # ɛ t o f o ; # i t o f o
+280	267	iedopo	idopo	i d o p o	i d o p o
+280	267	ètofo	Etofo	E t o f o	ɛ t o f o
+280	267	ietofo	itofo	i t o f o	i t o f o
 229	268	èroforofo	Eroforofo	E r o f o r o f o	ɛ r o f o r o f o
 171	269	èloro	Eloro	E l o r o	ɛ l o r o
 93	272	èèlako	EElako	E E l a k o	ɛ ɛ l a k o
-95	284	èènono: oefĕ	EEnono: ufė	E E n o n o : # u f ė	ɛ ɛ n o n o : # u f ə
+95	284	èènono:_oefĕ	EEnono:_ufė	E E n o n o : _ u f ė	ɛ ɛ n o n o : _ u f ə
 430	285	oeèfĕ	uEfė	u E f ė	u ɛ f ə
 96	286	èèolie	EEoli	E E o l i	ɛ ɛ o l i
 97	287	èèolieoekoewĕ	EEoliukuwė	E E o l i u k u w ė	ɛ ɛ o l i u k u w ə
@@ -106,32 +124,37 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 123	317	èhöarie	Ehu̇ari	E h u̇ a r i	ɛ h ɨ a r i
 411	318	mahöarie	mahu̇ari	m a h u̇ a r i	m a h ɨ a r i
 122	320	èho(w)afĕ	Eho(w)afė	E h o ( w ) a f ė	ɛ h o ( w ) a f ə
-91	335	èèdjie; èietjie	EEji; Eici	E E j i ; # E i c i	ɛ ɛ d͡ʒ i ; # ɛ i t͡ʃ i
+91	335	èèdjie	EEji	E E j i	ɛ ɛ d͡ʒ i
+91	335	èietjie	Eici	E i c i	ɛ i t͡ʃ i
 24	336	aèdjie	aEji	a E j i	a ɛ d͡ʒ i
 126	339	èieieoeloe	Eiiulu	E i i u l u	ɛ i i u l u
 124	342	èie(j)obĕ	Ei(y)obė	E i ( y ) o b ė	ɛ i ( j ) o b ə
 125	347	èiefĕ	Eifė	E i f ė	ɛ i f ə
 38	356	aniemaie	animai	a n i m a i	a n i m a i
 277	358	ie(j)araq	i(y)ara'	i ( y ) a r a '	i ( j ) a r a ʔ
-278	359	ie(j)araq noeha	i(y)ara' nuha	i ( y ) a r a ' # n u h a	i ( j ) a r a ʔ # n u h a
+278	359	ie(j)araq_noeha	i(y)ara'_nuha	i ( y ) a r a ' _ n u h a	i ( j ) a r a ʔ _ n u h a
 135	369	èkaraha(q)	Ekaraha(')	E k a r a h a ( ' )	ɛ k a r a h a ( ʔ )
 136	370	èkarieorie	Ekariori	E k a r i o r i	ɛ k a r i o r i
 128	371	èkadieofè	EkadiofE	E k a d i o f E	ɛ k a d i o f ɛ
 2	377	(è)kaèq	(E)kaE'	( E ) k a E '	( ɛ ) k a ɛ ʔ
-129	388	èkaie(oe)lahoe(hoe); èkaèdaho; èkaèlaho	Ekai(u)lahu(hu); EkaEdaho; EkaElaho	E k a i ( u ) l a h u ( h u ) ; # E k a E d a h o ; # E k a E l a h o	ɛ k a i ( u ) l a h u ( h u ) ; # ɛ k a ɛ d a h o ; # ɛ k a ɛ l a h o
+129	388	èkaie(oe)lahoe(hoe)	Ekai(u)lahu(hu)	E k a i ( u ) l a h u ( h u )	ɛ k a i ( u ) l a h u ( h u )
+129	388	èkaèdaho	EkaEdaho	E k a E d a h o	ɛ k a ɛ d a h o
+129	388	èkaèlaho	EkaElaho	E k a E l a h o	ɛ k a ɛ l a h o
 130	389	èkajoqfèdjie	Ekayo'fEji	E k a y o ' f E j i	ɛ k a j o ʔ f ɛ d͡ʒ i
 131	390	èkakorèie(j)ĕ	EkakorEi(y)ė	E k a k o r E i ( y ) ė	ɛ k a k o r ɛ i ( j ) ə
 127	398	èk(a)oeqfanoe	Ek(a)u'fanu	E k ( a ) u ' f a n u	ɛ k ( a ) u ʔ f a n u
 134	399	èkaoe(w)ĕ	Ekau(w)ė	E k a u ( w ) ė	ɛ k a u ( w ) ə
-139	405	èkĕlèpè; èkalèpè	EkėlEpE; EkalEpE	E k ė l E p E ; # E k a l E p E	ɛ k ə l ɛ p ɛ ; # ɛ k a l ɛ p ɛ
+139	405	èkĕlèpè	EkėlEpE	E k ė l E p E	ɛ k ə l ɛ p ɛ
+139	405	èkalèpè	EkalEpE	E k a l E p E	ɛ k a l ɛ p ɛ
 132	407	èkaliehĕ	Ekalihė	E k a l i h ė	ɛ k a l i ç ə
-133	408	èkaliehĕ oe(w)afĕ	Ekalihė u(w)afė	E k a l i h ė # u ( w ) a f ė	ɛ k a l i ç ə # u ( w ) a f ə
+133	408	èkaliehĕ_oe(w)afĕ	Ekalihė_u(w)afė	E k a l i h ė _ u ( w ) a f ė	ɛ k a l i ç ə _ u ( w ) a f ə
 137	411	èkèèfa	EkEEfa	E k E E f a	ɛ k ɛ ɛ f a
 344	412	kieèèfa	kiEEfa	k i E E f a	k i ɛ ɛ f a
 140	422	èkieafĕ	Ekiafė	E k i a f ė	ɛ k i a f ə
 146	423	èkietapè(j)a	EkitapE(y)a	E k i t a p E ( y ) a	ɛ k i t a p ɛ ( j ) a
 147	424	èkietiebèie(j)oq	EkitibEi(y)o'	E k i t i b E i ( y ) o '	ɛ k i t i b ɛ i ( j ) o ʔ
-145	425	èkietaie; èkiedaie	Ekitai; Ekidai	E k i t a i ; # E k i d a i	ɛ k i t a i ; # ɛ k i d a i
+145	425	èkietaie	Ekitai	E k i t a i	ɛ k i t a i
+145	425	èkiedaie	Ekidai	E k i d a i	ɛ k i d a i
 138	435	èkèhèö(j)a	EkEhEu̇(y)a	E k E h E u̇ ( y ) a	ɛ k ɛ h ɛ ɨ ( j ) a
 142	438	èkieie(j)ĕ	Ekii(y)ė	E k i i ( y ) ė	ɛ k i i ( j ) ə
 157	455	èkorie(j)o	Ekori(y)o	E k o r i ( y ) o	ɛ k o r i ( j ) o
@@ -154,13 +177,13 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 176	507	èmènahoe(w)a	EmEnahu(w)a	E m E n a h u ( w ) a	ɛ m ɛ n a h u ( w ) a
 175	509	èmèaö	EmEa'o	E m E a ' o	ɛ m ɛ a ʔ o
 177	514	èmoöie(j)ĕ	Emo'oi(y)ė	E m o ' o i ( y ) ė	ɛ m o ʔ o i ( j ) ə
-178	516	ènaè(na): oe(w)afĕ	EnaE(na): u(w)afė	E n a E ( n a ) : # u ( w ) a f ė	ɛ n a ɛ ( n a ) : # u ( w ) a f ə
+178	516	ènaè(na):_oe(w)afĕ	EnaE(na):_u(w)afė	E n a E ( n a ) : _ u ( w ) a f ė	ɛ n a ɛ ( n a ) : _ u ( w ) a f ə
 181	520	ènapĕ	Enapė	E n a p ė	ɛ n a p ə
 179	521	ènafienafie	Enafinafi	E n a f i n a f i	ɛ n a f i n a f i
 180	522	ènafienie	Enafini	E n a f i n i	ɛ n a f i n i
 182	530	ènoĕ	Enoė	E n o ė	ɛ n o ə
 205	537	èorie	Eori	E o r i	ɛ o r i
-42	538	apieha èoriedie(j)ĕ	apiha Eoridi(y)ė	a p i h a # E o r i d i ( y ) ė	a p i ç a # ɛ o r i d i ( j ) ə
+42	538	apieha_èoriedie(j)ĕ	apiha_Eoridi(y)ė	a p i h a _ E o r i d i ( y ) ė	a p i ç a _ ɛ o r i d i ( j ) ə
 206	539	èorieaäq	Eoria'a'	E o r i a ' a '	ɛ o r i a ʔ a ʔ
 57	540	borieaäq	boria'a'	b o r i a ' a '	b o r i a ʔ a ʔ
 315	541	kahohoriaäq	kahohoria'a'	k a h o h o r i a ' a '	k a h o h o r i a ʔ a ʔ
@@ -168,12 +191,12 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 208	546	èoroe	Eoru	E o r u	ɛ o r u
 209	547	èorohèie	EorohEi	E o r o h E i	ɛ o r o h ɛ i
 188	548	èoebĕ	Eubė	E u b ė	ɛ u b ə
-189	549	èoebĕ: èkaèn	Eubė: EkaEn	E u b ė : # E k a E n	ɛ u b ə : # ɛ k a ɛ n
+189	549	èoebĕ:_èkaèn	Eubė:_EkaEn	E u b ė : _ E k a E n	ɛ u b ə : _ ɛ k a ɛ n
 141	550	èkiearoboe	Ekiarobu	E k i a r o b u	ɛ k i a r o b u
 185	551	èobo	Eobo	E o b o	ɛ o b o
 334	553	kèèèfĕ	kEEEfė	k E E E f ė	k ɛ ɛ ɛ f ə
 195	556	èoeloe	Eulu	E u l u	ɛ u l u
-196	557	èoeloe bèlo(w)a	Eulu bElo(w)a	E u l u # b E l o ( w ) a	ɛ u l u # b ɛ l o ( w ) a
+196	557	èoeloe_bèlo(w)a	Eulu_bElo(w)a	E u l u _ b E l o ( w ) a	ɛ u l u _ b ɛ l o ( w ) a
 192	563	èoekoeriepo	Eukuripo	E u k u r i p o	ɛ u k u r i p o
 197	569	èoemĕ	Eumė	E u m ė	ɛ u m ə
 198	573	èoeoe(w)afĕ	Eu'u(w)afė	E u ' u ( w ) a f ė	ɛ u ʔ u ( w ) a f ə
@@ -181,8 +204,12 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 199	576	èoepoeie(j)ĕ	Eupui(y)ė	E u p u i ( y ) ė	ɛ u p u i ( j ) ə
 200	577	èoepoeqoe(w)ĕ	Eupu'u(w)ė	E u p u ' u ( w ) ė	ɛ u p u ʔ u ( w ) ə
 191	578	èoefoe(w)a	Eufu(w)a	E u f u ( w ) a	ɛ u f u ( w ) a
-186	580	èoe(w)aè; èè(w)aie; èè(w)aè	Eu(w)aE; EE(w)ai; EE(w)aE	E u ( w ) a E ; # E E ( w ) a i ; # E E ( w ) a E	ɛ u ( w ) a ɛ ; # ɛ ɛ ( w ) a i ; # ɛ ɛ ( w ) a ɛ
-187	582	èoe(w)afĕ; èè(w)apo; èèwafĕ	Eu(w)afė; EE(w)apo; EEwafė	E u ( w ) a f ė ; # E E ( w ) a p o ; # E E w a f ė	ɛ u ( w ) a f ə ; # ɛ ɛ ( w ) a p o ; # ɛ ɛ w a f ə
+186	580	èoe(w)aè	Eu(w)aE	E u ( w ) a E	ɛ u ( w ) a ɛ
+186	580	èè(w)aie	EE(w)ai	E E ( w ) a i	ɛ ɛ ( w ) a i
+186	580	èè(w)aè	EE(w)aE	E E ( w ) a E	ɛ ɛ ( w ) a ɛ
+187	582	èoe(w)afĕ	Eu(w)afė	E u ( w ) a f ė	ɛ u ( w ) a f ə
+187	582	èè(w)apo	EE(w)apo	E E ( w ) a p o	ɛ ɛ ( w ) a p o
+187	582	èèwafĕ	EEwafė	E E w a f ė	ɛ ɛ w a f ə
 63	584	è(o)horaoekèèfa	E(o)horaukEEfa	E ( o ) h o r a u k E E f a	ɛ ( o ) h o r a u k ɛ ɛ f a
 202	586	èokahaĕ	Eokahaė	E o k a h a ė	ɛ o k a h a ə
 203	592	èokoehèoeloe	EokuhEulu	E o k u h E u l u	ɛ o k u h ɛ u l u
@@ -193,13 +220,16 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 210	627	èpahoahoäq	Epahoaho'a'	E p a h o a h o ' a '	ɛ p a h o a h o ʔ a ʔ
 99	633	èfakoehè	EfakuhE	E f a k u h E	ɛ f a k u h ɛ
 211	635	èpak(a)(w)ĕ	Epak(a)(w)ė	E p a k ( a ) ( w ) ė	ɛ p a k ( a ) ( w ) ə
-100	636	èfalè; èparè	EfalE; EparE	E f a l E ; # E p a r E	ɛ f a l ɛ ; # ɛ p a r ɛ
+100	636	èfalè	EfalE	E f a l E	ɛ f a l ɛ
+100	636	èparè	EparE	E p a r E	ɛ p a r ɛ
 101	638	èfanoe	Efanu	E f a n u	ɛ f a n u
-212	640	èpanĕma; èfanĕma	Epanėma; Efanėma	E p a n ė m a ; # E f a n ė m a	ɛ p a n ə m a ; # ɛ f a n ə m a
+212	640	èpanĕma	Epanėma	E p a n ė m a	ɛ p a n ə m a
+212	640	èfanĕma	Efanėma	E f a n ė m a	ɛ f a n ə m a
 103	642	èfaofĕ	Efaofė	E f a o f ė	ɛ f a o f ə
 104	643	èfaoqöqaie	Efao'u̇'ai	E f a o ' u̇ ' a i	ɛ f a o ʔ ɨ ʔ a i
 105	645	èfèa	EfEa	E f E a	ɛ f ɛ a
-213	649	èpèdoe(w)a(ö); èfèlo(w)a(ö)	EpEdu(w)a('o); EfElo(w)a('o)	E p E d u ( w ) a ( ' o ) ; # E f E l o ( w ) a ( ' o )	ɛ p ɛ d u ( w ) a ( ʔ o ) ; # ɛ f ɛ l o ( w ) a ( ʔ o )
+213	649	èpèdoe(w)a(ö)	EpEdu(w)a('o)	E p E d u ( w ) a ( ' o )	ɛ p ɛ d u ( w ) a ( ʔ o )
+213	649	èfèlo(w)a(ö)	EfElo(w)a('o)	E f E l o ( w ) a ( ' o )	ɛ f ɛ l o ( w ) a ( ʔ o )
 106	650	èfèhè	EfEhE	E f E h E	ɛ f ɛ h ɛ
 214	654	èpĕrhaoedie	Epėrhaudi	E p ė r h a u d i	ɛ p ə r h a u d i
 215	657	èpieaoe(w)afĕ	Epiau(w)afė	E p i a u ( w ) a f ė	ɛ p i a u ( w ) a f ə
@@ -211,11 +241,11 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 60	669	epoeaoe	epuau	e p u a u	e p u a u
 220	671	èpoeroe	Epuru	E p u r u	ɛ p u r u
 112	674	èfoekĕ	Efukė	E f u k ė	ɛ f u k ə
-219	678	èpoe(oe)qoe: oe(w)afĕ	Epu(u)'u: u(w)afė	E p u ( u ) ' u : # u ( w ) a f ė	ɛ p u ( u ) ʔ u : # u ( w ) a f ə
+219	678	èpoe(oe)qoe:_oe(w)afĕ	Epu(u)'u:_u(w)afė	E p u ( u ) ' u : _ u ( w ) a f ė	ɛ p u ( u ) ʔ u : _ u ( w ) a f ə
 221	680	èpoeroeroe(ie)	Epururu(i)	E p u r u r u ( i )	ɛ p u r u r u ( i )
-223	681	èpoeroeroe(ie): èoeloe	Epururu(i): Eulu	E p u r u r u ( i ) : # E u l u	ɛ p u r u r u ( i ) : # ɛ u l u
+223	681	èpoeroeroe(ie):_èoeloe	Epururu(i):_Eulu	E p u r u r u ( i ) : _ E u l u	ɛ p u r u r u ( i ) : _ ɛ u l u
 222	683	èpoeroeroe(ie)	Epururu(i)	E p u r u r u ( i )	ɛ p u r u r u ( i )
-224	684	èpoeroeroe(ie): waniemaie	Epururu(i): wanimai	E p u r u r u ( i ) : # w a n i m a i	ɛ p u r u r u ( i ) : # w a n i m a i
+224	684	èpoeroeroe(ie):_waniemaie	Epururu(i):_wanimai	E p u r u r u ( i ) : _ w a n i m a i	ɛ p u r u r u ( i ) : _ w a n i m a i
 437	686	oekèoq	ukEo'	u k E o '	u k ɛ o ʔ
 217	687	èpoe(ah)ha	Epu(ah)ha	E p u ( a h ) h a	ɛ p u ( a h ) h a
 111	688	èfo(h)	Efo(h)	E f o ( h )	ɛ f o ( h )
@@ -239,8 +269,10 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 279	767	iedjo	ijo	i j o	i d͡ʒ o
 287	772	kaä(ä)ou(w)ĕ	ka'a('a)ou(w)ė	k a ' a ( ' a ) o u ( w ) ė	k a ʔ a ( ʔ a ) o u ( w ) ə
 295	773	kaärahĕaie	ka'arahėai	k a ' a r a h ė a i	k a ʔ a r a h ə a i
-288	775	kaädoie(j)ĕ; kaäroie(j)ĕ	ka'adoi(y)ė; ka'aroi(y)ė	k a ' a d o i ( y ) ė ; # k a ' a r o i ( y ) ė	k a ʔ a d o i ( j ) ə ; # k a ʔ a r o i ( j ) ə
-290	784	kaäkènè; kakanie(q)	ka'akEnE; kakani(')	k a ' a k E n E ; # k a k a n i ( ' )	k a ʔ a k ɛ n ɛ ; # k a k a n i ( ʔ )
+288	775	kaädoie(j)ĕ	ka'adoi(y)ė	k a ' a d o i ( y ) ė	k a ʔ a d o i ( j ) ə
+288	775	kaäroie(j)ĕ	ka'aroi(y)ė	k a ' a r o i ( y ) ė	k a ʔ a r o i ( j ) ə
+290	784	kaäkènè	ka'akEnE	k a ' a k E n E	k a ʔ a k ɛ n ɛ
+290	784	kakanie(q)	kakani(')	k a k a n i ( ' )	k a k a n i ( ʔ )
 291	785	kaäkieniefĕ	ka'akinifė	k a ' a k i n i f ė	k a ʔ a k i n i f ə
 293	791	kaäpĕaäaq	ka'apėa'aa'	k a ' a p ė a ' a a '	k a ʔ a p ə a ʔ a a ʔ
 289	792	kaäfoho	ka'afoho	k a ' a f o h o	k a ʔ a f o h o
@@ -253,7 +285,7 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 314	825	kahoho	kahoho	k a h o h o	k a h o h o
 308	828	kahaienoeafĕ	kahainuafė	k a h a i n u a f ė	k a h a i n u a f ə
 309	831	kahakoudĕ	kahakoudė	k a h a k o u d ė	k a h a k o u d ə
-310	833	kahao: èmanè	kahao: EmanE	k a h a o : # E m a n E	k a h a o : # ɛ m a n ɛ
+310	833	kahao:_èmanè	kahao:_EmanE	k a h a o : _ E m a n E	k a h a o : _ ɛ m a n ɛ
 311	836	kahaokĕ	kahaokė	k a h a o k ė	k a h a o k ə
 306	837	kahafaq	kahafa'	k a h a f a '	k a h a f a ʔ
 307	838	kahafie	kahafi	k a h a f i	k a h a f i
@@ -273,7 +305,7 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 292	917	kaäöbo	ka'au̇bo	k a ' a u̇ b o	k a ʔ a ɨ b o
 327	918	kaoöèèdjie	kao'oEEji	k a o ' o E E j i	k a o ʔ o ɛ ɛ d͡ʒ i
 300	921	kafal	kafal	k a f a l	k a f a l
-301	922	kafàl afi	kafal afi	k a f a l # a f i	k a f a l # a f i
+301	922	kafàl_afi	kafal_afi	k a f a l _ a f i	k a f a l _ a f i
 302	924	kafĕrafĕraba	kafėrafėraba	k a f ė r a f ė r a b a	k a f ə r a f ə r a b a
 303	928	kafoekĕ	kafukė	k a f u k ė	k a f u k ə
 304	931	kafofo	kafofo	k a f o f o	k a f o f o
@@ -281,20 +313,23 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 318	938	kaliepoliepo	kalipolipo	k a l i p o l i p o	k a l i p o l i p o
 329	940	karohajĕ	karohayė	k a r o h a y ė	k a r o h a j ə
 335	952	kèhorojo	kEhoroyo	k E h o r o y o	k ɛ h o r o j o
-8	962	(è)kiadoboe; (è)kiaroboe	(E)kiadobu; (E)kiarobu	( E ) k i a d o b u ; # ( E ) k i a r o b u	( ɛ ) k i a d o b u ; # ( ɛ ) k i a r o b u
+8	962	(è)kiadoboe	(E)kiadobu	( E ) k i a d o b u	( ɛ ) k i a d o b u
+8	962	(è)kiaroboe	(E)kiarobu	( E ) k i a r o b u	( ɛ ) k i a r o b u
 340	968	kiebèrieka	kibErika	k i b E r i k a	k i b ɛ r i k a
 390	971	kietahoho	kitahoho	k i t a h o h o	k i t a h o h o
 389	972	kietahaq	kitaha'	k i t a h a '	k i t a h a ʔ
-387	977	kierèdèjaq; kèdèdè(j)aq; kèrèdè(j)aq	kirEdEya'; kEdEdE(y)a'; kErEdE(y)a'	k i r E d E y a ' ; # k E d E d E ( y ) a ' ; # k E r E d E ( y ) a '	k i r ɛ d ɛ j a ʔ ; # k ɛ d ɛ d ɛ ( j ) a ʔ ; # k ɛ r ɛ d ɛ ( j ) a ʔ
+387	977	kierèdèjaq	kirEdEya'	k i r E d E y a '	k i r ɛ d ɛ j a ʔ
+387	977	kèdèdè(j)aq	kEdEdE(y)a'	k E d E d E ( y ) a '	k ɛ d ɛ d ɛ ( j ) a ʔ
+387	977	kèrèdè(j)aq	kErEdE(y)a'	k E r E d E ( y ) a '	k ɛ r ɛ d ɛ ( j ) a ʔ
 341	985	kiedaieie(j)aq	kidaii(y)a'	k i d a i i ( y ) a '	k i d a i i ( j ) a ʔ
 392	990	kieto	kito	k i t o	k i t o
 388	991	kierobieka	kirobika	k i r o b i k a	k i r o b i k a
-343	993	kiedodo èdjie	kidodo Eji	k i d o d o # E j i	k i d o d o # ɛ d͡ʒ i
+343	993	kiedodo_èdjie	kidodo_Eji	k i d o d o _ E j i	k i d o d o _ ɛ d͡ʒ i
 366	1000	kiehiema(na)èorie	kihima(na)Eori	k i h i m a ( n a ) E o r i	k i ç i m a ( n a ) ɛ o r i
 367	1005	kieie(j)oèraha	kii(y)uraha	k i i ( y ) u r a h a	k i i ( j ) u r a h a
 368	1006	kieiefĕ	kiifė	k i i f ė	k i i f ə
 330	1009	kè(j)abaq	kE(y)aba'	k E ( y ) a b a '	k ɛ ( j ) a b a ʔ
-332	1010	kè(j)abaq iekèo	kE(y)aba' ikEo	k E ( y ) a b a ' # i k E o	k ɛ ( j ) a b a ʔ # i k ɛ o
+332	1010	kè(j)abaq_iekèo	kE(y)aba'_ikEo	k E ( y ) a b a ' _ i k E o	k ɛ ( j ) a b a ʔ _ i k ɛ o
 338	1013	kie(j)oenanĕ	ki(y)unanė	k i ( y ) u n a n ė	k i ( j ) u n a n ə
 339	1014	kie(j)oèroha	ki(y)uroha	k i ( y ) u r o h a	k i ( j ) u r o h a
 333	1015	kè(j)oha	kE(y)oha	k E ( y ) o h a	k ɛ ( j ) o h a
@@ -304,7 +339,7 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 372	1039	kiekoekoe(q)ĕ	kikuku(')ė	k i k u k u ( ' ) ė	k i k u k u ( ʔ ) ə
 408	1043	kokonienie	kokonini	k o k o n i n i	k o k o n i n i
 373	1054	kienanafĕ	kinanafė	k i n a n a f ė	k i n a n a f ə
-374	1062	kienono: è(j)ĕ	kinono: E(y)ė	k i n o n o : # E ( y ) ė	k i n o n o : # ɛ ( j ) ə
+374	1062	kienono:_è(j)ĕ	kinono:_E(y)ė	k i n o n o : _ E ( y ) ė	k i n o n o : _ ɛ ( j ) ə
 62	1063	è(j)adie(j)ĕ	E(y)adi(y)ė	E ( y ) a d i ( y ) ė	ɛ ( j ) a d i ( j ) ə
 375	1066	kienoqè(j)ĕ	kino'E(y)ė	k i n o ' E ( y ) ė	k i n o ʔ ɛ ( j ) ə
 378	1067	kieorèa	kiorEa	k i o r E a	k i o r ɛ a
@@ -313,15 +348,18 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 345	1077	kiefa(a)oeq	kifa(a)u'	k i f a ( a ) u '	k i f a ( a ) u ʔ
 379	1078	kiepadieoeièdjie	kipadiuiji	k i p a d i u i j i	k i p a d i u i d͡ʒ i
 352	1079	kiefahoe(w)a	kifahu(w)a	k i f a h u ( w ) a	k i f a h u ( w ) a
-353	1083	kiefakiefa fahoeoenaq	kifakifa fahu'una'	k i f a k i f a # f a h u ' u n a '	k i f a k i f a # f a h u ʔ u n a ʔ
+353	1083	kiefakiefa_fahoeoenaq	kifakifa_fahu'una'	k i f a k i f a _ f a h u ' u n a '	k i f a k i f a _ f a h u ʔ u n a ʔ
 380	1087	kiepakoekoe	kipakuku	k i p a k u k u	k i p a k u k u
 381	1088	kiepakoekoekie	kipakukuki	k i p a k u k u k i	k i p a k u k u k i
 354	1090	kiefamĕ	kifamė	k i f a m ė	k i f a m ə
 351	1092	kiefafakoe	kifafaku	k i f a f a k u	k i f a f a k u
 355	1093	kiefaqaq	kifa'a'	k i f a ' a '	k i f a ʔ a ʔ
 382	1094	kieparaèbahoe(q)	kiparaEbahu(')	k i p a r a E b a h u ( ' )	k i p a r a ɛ b a h u ( ʔ )
-383	1098	kieparaèdie(j)oq; kiefalaiedie(j)oq	kiparaEdi(y)o'; kifalaidi(y)o'	k i p a r a E d i ( y ) o ' ; # k i f a l a i d i ( y ) o '	k i p a r a ɛ d i ( j ) o ʔ ; # k i f a l a i d i ( j ) o ʔ
-357	1099	kiefĕhaie; kiepoehaie; kiefoehaie	kifėhai; kipuhai; kifuhai	k i f ė h a i ; # k i p u h a i ; # k i f u h a i	k i f ə h a i ; # k i p u h a i ; # k i f u h a i
+383	1098	kieparaèdie(j)oq	kiparaEdi(y)o'	k i p a r a E d i ( y ) o '	k i p a r a ɛ d i ( j ) o ʔ
+383	1098	kiefalaiedie(j)oq	kifalaidi(y)o'	k i f a l a i d i ( y ) o '	k i f a l a i d i ( j ) o ʔ
+357	1099	kiefĕhaie	kifėhai	k i f ė h a i	k i f ə h a i
+357	1099	kiepoehaie	kipuhai	k i p u h a i	k i p u h a i
+357	1099	kiefoehaie	kifuhai	k i f u h a i	k i f u h a i
 358	1101	kiefĕhodĕ	kifėhodė	k i f ė h o d ė	k i f ə h o d ə
 356	1102	kiefèoraq	kifEora'	k i f E o r a '	k i f ɛ o r a ʔ
 359	1103	kiefiefie	kififi	k i f i f i	k i f i f i
@@ -329,39 +367,52 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 385	1106	kiepoerieka	kipurika	k i p u r i k a	k i p u r i k a
 361	1107	kiefoefoe	kifufu	k i f u f u	k i f u f u
 362	1108	kiefoeoedĕ	kifu'udė	k i f u ' u d ė	k i f u ʔ u d ə
-360	1109	kiefoe(w)a; kiepö(w)a; kiefö(w)a	kifu(w)a; kipu̇(w)a; kifu̇(w)a	k i f u ( w ) a ; # k i p u̇ ( w ) a ; # k i f u̇ ( w ) a	k i f u ( w ) a ; # k i p ɨ ( w ) a ; # k i f ɨ ( w ) a
+360	1109	kiefoe(w)a	kifu(w)a	k i f u ( w ) a	k i f u ( w ) a
+360	1109	kiepö(w)a	kipu̇(w)a	k i p u̇ ( w ) a	k i p ɨ ( w ) a
+360	1109	kiefö(w)a	kifu̇(w)a	k i f u̇ ( w ) a	k i f ɨ ( w ) a
 364	1111	kiefokana	kifokana	k i f o k a n a	k i f o k a n a
 365	1112	kiefokiefo	kifokifo	k i f o k i f o	k i f o k i f o
 363	1114	kiefofoä	kifofo'a	k i f o f o ' a	k i f o f o ʔ a
 386	1116	kieqjĕ	ki'yė	k i ' y ė	k i ʔ j ə
 409	1117	koq(a)hajo	ko'(a)hayo	k o ' ( a ) h a y o	k o ʔ ( a ) h a j o
 393	1118	koahie(j)ĕ	koahi(y)ė	k o a h i ( y ) ė	k o a h i ( j ) ə
-394	1119	koahie(j)ĕ kafoe	koahi(y)ė kafu	k o a h i ( y ) ė # k a f u	k o a h i ( j ) ə # k a f u
+394	1119	koahie(j)ĕ_kafoe	koahi(y)ė_kafu	k o a h i ( y ) ė _ k a f u	k o a h i ( j ) ə _ k a f u
 395	1123	koeana	kuana	k u a n a	k u a n a
 286	1128	ietofo	itofo	i t o f o	i t o f o
-150	1130	èkoedodoka; koedoroka	Ekudodoka; kudoroka	E k u d o d o k a ; # k u d o r o k a	ɛ k u d o d o k a ; # k u d o r o k a
+150	1130	èkoedodoka	Ekudodoka	E k u d o d o k a	ɛ k u d o d o k a
+150	1130	koedoroka	kudoroka	k u d o r o k a	k u d o r o k a
 401	1131	koeroe	kuru	k u r u	k u r u
-404	1133	kohèdie; koehèlie; kohèlie	kohEdi; kuhEli; kohEli	k o h E d i ; # k u h E l i ; # k o h E l i	k o h ɛ d i ; # k u h ɛ l i ; # k o h ɛ l i
+404	1133	kohèdie	kohEdi	k o h E d i	k o h ɛ d i
+404	1133	koehèlie	kuhEli	k u h E l i	k u h ɛ l i
+404	1133	kohèlie	kohEli	k o h E l i	k o h ɛ l i
 396	1134	koehèlie(j)aq	kuhEli(y)a'	k u h E l i ( y ) a '	k u h ɛ l i ( j ) a ʔ
-397	1136	koeie kaliehĕ	kui kalihė	k u i # k a l i h ė	k u i # k a l i ç ə
-398	1138	koeienanaq; koienaq; koenènaq, koenanaq	kuinana'; koina'; kunEna', kunana'	k u i n a n a ' ; # k o i n a ' ; # k u n E n a ' , # k u n a n a '	k u i n a n a ʔ ; # k o i n a ʔ ; # k u n ɛ n a ʔ , # k u n a n a ʔ
+397	1136	koeie_kaliehĕ	kui_kalihė	k u i _ k a l i h ė	k u i _ k a l i ç ə
+398	1138	koeienanaq	kuinana'	k u i n a n a '	k u i n a n a ʔ
+398	1138	koienaq	koina'	k o i n a '	k o i n a ʔ
+398	1138	koenènaq,_koenanaq	kunEna',_kunana'	k u n E n a ' , _ k u n a n a '	k u n ɛ n a ʔ , _ k u n a n a ʔ
 400	1142	koemènoeĕ	kumEnuė	k u m E n u ė	k u m ɛ n u ə
 399	1146	koelipo	kulipo	k u l i p o	k u l i p o
 405	1150	kohofaie	kohofai	k o h o f a i	k o h o f a i
-406	1151	kohofie(j)ĕ; kopopoie(j)ĕ (?)	kohofi(y)ė; kopopoi(y)ė (?)	k o h o f i ( y ) ė ; # k o p o p o i ( y ) ė # ( ? )	k o h o f i ( j ) ə ; # k o p o p o i ( j ) ə # ( ? )
+406	1151	kohofie(j)ĕ	kohofi(y)ė	k o h o f i ( y ) ė	k o h o f i ( j ) ə
+406	1151	kopopoie(j)ĕ_(?)	kopopoi(y)ė_(?)	k o p o p o i ( y ) ė _ ( ? )	k o p o p o i ( j ) ə _ ( ? )
 407	1156	kokonĕ	kokonė	k o k o n ė	k o k o n ə
 402	1167	kofo	kofo	k o f o	k o f o
 403	1168	koforieqie	kofori'i	k o f o r i ' i	k o f o r i ʔ i
-299	1169	kadoqö (?)	kado'u̇ (?)	k a d o ' u̇ # ( ? )	k a d o ʔ ɨ # ( ? )
-418	1175	mohona(q); ahiemahona(q)	mohona('); ahimahona(')	m o h o n a ( ' ) ; # a h i m a h o n a ( ' )	m o h o n a ( ʔ ) ; # a h i m a h o n a ( ʔ )
+299	1169	kadoqö_(?)	kado'u̇_(?)	k a d o ' u̇ _ ( ? )	k a d o ʔ ɨ _ ( ? )
+418	1175	mohona(q)	mohona(')	m o h o n a ( ' )	m o h o n a ( ʔ )
+418	1175	ahiemahona(q)	ahimahona(')	a h i m a h o n a ( ' )	a h i m a h o n a ( ʔ )
 420	1177	monokie	monoki	m o n o k i	m o n o k i
 415	1180	mienaoe(w)afĕ	minau(w)afė	m i n a u ( w ) a f ė	m i n a u ( w ) a f ə
 414	1181	mienaoe(w)aè	minau(w)aE	m i n a u ( w ) a E	m i n a u ( w ) a ɛ
 417	1185	mohomohoienoe	mohomohoinu	m o h o m o h o i n u	m o h o m o h o i n u
 439	1186	omokie	omoki	o m o k i	o m o k i
-419	1188	moko èorie die(j)ĕ	moko Eori di(y)ė	m o k o # E o r i # d i ( y ) ė	m o k o # ɛ o r i # d i ( j ) ə
+419	1188	moko_èorie_die(j)ĕ	moko_Eori_di(y)ė	m o k o _ E o r i _ d i ( y ) ė	m o k o _ ɛ o r i _ d i ( j ) ə
 421	1191	naäfoe(w)aka(q)	na'afu(w)aka(')	n a ' a f u ( w ) a k a ( ' )	n a ʔ a f u ( w ) a k a ( ʔ )
-422	1192	naähapè; naäpè; naèhafè; noähafè; naäfè	na'ahapE; na'apE; naEhafE; no'ahafE; na'afE	n a ' a h a p E ; # n a ' a p E ; # n a E h a f E ; # n o ' a h a f E ; # n a ' a f E	n a ʔ a h a p ɛ ; # n a ʔ a p ɛ ; # n a ɛ h a f ɛ ; # n o ʔ a h a f ɛ ; # n a ʔ a f ɛ
+422	1192	naähapè	na'ahapE	n a ' a h a p E	n a ʔ a h a p ɛ
+422	1192	naäpè	na'apE	n a ' a p E	n a ʔ a p ɛ
+422	1192	naèhafè	naEhafE	n a E h a f E	n a ɛ h a f ɛ
+422	1192	noähafè	no'ahafE	n o ' a h a f E	n o ʔ a h a f ɛ
+422	1192	naäfè	na'afE	n a ' a f E	n a ʔ a f ɛ
 423	1196	nafonaq	nafona'	n a f o n a '	n a f o n a ʔ
 424	1199	nèènè	nEEnE	n E E n E	n ɛ ɛ n ɛ
 425	1201	nie(j)ĕ	ni(y)ė	n i ( y ) ė	n i ( j ) ə
@@ -382,19 +433,23 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 235	1246	faboedajaq	fabudaya'	f a b u d a y a '	f a b u d a j a ʔ
 236	1247	faböha	fabu̇ha	f a b u̇ h a	f a b ɨ h a
 237	1248	fadahèboe(w)ĕ	fadahEbu(w)ė	f a d a h E b u ( w ) ė	f a d a h ɛ b u ( w ) ə
-260	1250	fariehoie(j)aqä; faliehoie(j)aqä	farihoi(y)a'a; falihoi(y)a'a	f a r i h o i ( y ) a ' a ; # f a l i h o i ( y ) a ' a	f a r i ç o i ( j ) a ʔ a ; # f a l i ç o i ( j ) a ʔ a
+260	1250	fariehoie(j)aqä	farihoi(y)a'a	f a r i h o i ( y ) a ' a	f a r i ç o i ( j ) a ʔ a
+260	1250	faliehoie(j)aqä	falihoi(y)a'a	f a l i h o i ( y ) a ' a	f a l i ç o i ( j ) a ʔ a
 259	1251	fariehofie	farihofi	f a r i h o f i	f a r i ç o f i
 261	1252	fariekaä	farika'a	f a r i k a ' a	f a r i k a ʔ a
 443	1255	paèloha	paEloha	p a E l o h a	p a ɛ l o h a
 444	1260	pahabie(j)aq	pahabi(y)a'	p a h a b i ( y ) a '	p a h a b i ( j ) a ʔ
 233	1262	fa(ha)böhaq	fa(ha)bu̇ha'	f a ( h a ) b u̇ h a '	f a ( h a ) b ɨ h a ʔ
-241	1264	fahaloho; fahaloho èkiedjaie(j)oe	fahaloho; fahaloho Ekijai(y)u	f a h a l o h o ; # f a h a l o h o # E k i j a i ( y ) u	f a h a l o h o ; # f a h a l o h o # ɛ k i d͡ʒ a i ( j ) u
+241	1264	fahaloho	fahaloho	f a h a l o h o	f a h a l o h o
+241	1264	fahaloho_èkiedjaie(j)oe	fahaloho_Ekijai(y)u	f a h a l o h o _ E k i j a i ( y ) u	f a h a l o h o _ ɛ k i d͡ʒ a i ( j ) u
 445	1267	pahakie(j)o	pahaki(y)o	p a h a k i ( y ) o	p a h a k i ( j ) o
 240	1271	fahafoeè(q)	fahafuE(')	f a h a f u E ( ' )	f a h a f u ɛ ( ʔ )
 242	1272	fahjĕ	fahyė	f a h y ė	f a h j ə
 243	1274	fahoehoeroe	fahuhuru	f a h u h u r u	f a h u h u r u
 244	1279	faienènèaq	fainEnEa'	f a i n E n E a '	f a i n ɛ n ɛ a ʔ
-454	1280	pĕkahadè; pakahalè; pĕkahalè	pėkahadE; pakahalE; pėkahalE	p ė k a h a d E ; # p a k a h a l E ; # p ė k a h a l E	p ə k a h a d ɛ ; # p a k a h a l ɛ ; # p ə k a h a l ɛ
+454	1280	pĕkahadè	pėkahadE	p ė k a h a d E	p ə k a h a d ɛ
+454	1280	pakahalè	pakahalE	p a k a h a l E	p a k a h a l ɛ
+454	1280	pĕkahalè	pėkahalE	p ė k a h a l E	p ə k a h a l ɛ
 245	1281	fakahofĕ	fakahofė	f a k a h o f ė	f a k a h o f ə
 246	1283	fakarahaq	fakaraha'	f a k a r a h a '	f a k a r a h a ʔ
 247	1286	fakèrie(j)a	fakEri(y)a	f a k E r i ( y ) a	f a k ɛ r i ( j ) a
@@ -402,15 +457,17 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 249	1292	fakoehè	fakuhE	f a k u h E	f a k u h ɛ
 447	1293	pakoehè(j)aq	pakuhE(y)a'	p a k u h E ( y ) a '	p a k u h ɛ ( j ) a ʔ
 250	1294	fakoehö(j)aq	fakuhu̇(y)a'	f a k u h u̇ ( y ) a '	f a k u h ɨ ( j ) a ʔ
-336	1297	kèo pakoenaq aèkietaieboe	kEo pakuna' aEkitaibu	k E o # p a k u n a ' # a E k i t a i b u	k ɛ o # p a k u n a ʔ # a ɛ k i t a i b u
+336	1297	kèo_pakoenaq_aèkietaieboe	kEo_pakuna'_aEkitaibu	k E o _ p a k u n a ' _ a E k i t a i b u	k ɛ o _ p a k u n a ʔ _ a ɛ k i t a i b u
 448	1299	pakoeqäq	paku'a'	p a k u ' a '	p a k u ʔ a ʔ
 248	1300	fakoefèq	fakufE'	f a k u f E '	f a k u f ɛ ʔ
 449	1305	pamahaoma	pamahaoma	p a m a h a o m a	p a m a h a o m a
 284	1306	iepamahona	ipamahona	i p a m a h o n a	i p a m a h o n a
 252	1308	fana(h)	fana(h)	f a n a ( h )	f a n a ( h )
-253	1309	fanako; pĕnĕko; fĕnĕko	fanako; pėnėko; fėnėko	f a n a k o ; # p ė n ė k o ; # f ė n ė k o	f a n a k o ; # p ə n ə k o ; # f ə n ə k o
+253	1309	fanako	fanako	f a n a k o	f a n a k o
+253	1309	pĕnĕko	pėnėko	p ė n ė k o	p ə n ə k o
+253	1309	fĕnĕko	fėnėko	f ė n ė k o	f ə n ə k o
 254	1310	fanakonĕ	fanakonė	f a n a k o n ė	f a n a k o n ə
-331	1311	kè(j)abaq fanakonĕ	kE(y)aba' fanakonė	k E ( y ) a b a ' # f a n a k o n ė	k ɛ ( j ) a b a ʔ # f a n a k o n ə
+331	1311	kè(j)abaq_fanakonĕ	kE(y)aba'_fanakonė	k E ( y ) a b a ' _ f a n a k o n ė	k ɛ ( j ) a b a ʔ _ f a n a k o n ə
 255	1312	fanakonĕäq	fanakonė'a'	f a n a k o n ė ' a '	f a n a k o n ə ʔ a ʔ
 256	1313	fanaoe	fanau	f a n a u	f a n a u
 257	1315	fanè	fanE	f a n E	f a n ɛ
@@ -425,39 +482,46 @@ ID	FORM_ID	variant	variant_common_transcription	variant_common_segments	variant_
 262	1336	farieqö	fari'u̇	f a r i ' u̇	f a r i ʔ ɨ
 263	1337	faroefèie	farufEi	f a r u f E i	f a r u f ɛ i
 264	1340	faroriefo	farorifo	f a r o r i f o	f a r o r i f o
-453	1341	pèè; aboepè	pEE; abupE	p E E ; # a b u p E	p ɛ ɛ ; # a b u p ɛ
+453	1341	pèè	pEE	p E E	p ɛ ɛ
+453	1341	aboepè	abupE	a b u p E	a b u p ɛ
 265	1343	fè(j)aha	fE(y)aha	f E ( y ) a h a	f ɛ ( j ) a h a
-457	1346	pĕnjako; fènjako; fĕnjako	pėñako; fEñako; fėñako	p ė ñ a k o ; # f E ñ a k o ; # f ė ñ a k o	p ə ɲ a k o ; # f ɛ ɲ a k o ; # f ə ɲ a k o
+457	1346	pĕnjako	pėñako	p ė ñ a k o	p ə ɲ a k o
+457	1346	fènjako	fEñako	f E ñ a k o	f ɛ ɲ a k o
+457	1346	fĕnjako	fėñako	f ė ñ a k o	f ə ɲ a k o
 266	1347	fènohie(j)o	fEnohi(y)o	f E n o h i ( y ) o	f ɛ n o h i ( j ) o
 267	1348	fiehie	fihi	f i h i	f i ç i
 456	1353	pĕnahaäq	pėnaha'a'	p ė n a h a ' a '	p ə n a h a ʔ a ʔ
-459	1360	poepoeroe; foefoeroe	pupuru; fufuru	p u p u r u ; # f u f u r u	p u p u r u ; # f u f u r u
-458	1362	poelieho; foeliehĕ	puliho; fulihė	p u l i h o ; # f u l i h ė	p u l i ç o ; # f u l i ç ə
+459	1360	poepoeroe	pupuru	p u p u r u	p u p u r u
+459	1360	foefoeroe	fufuru	f u f u r u	f u f u r u
+458	1362	poelieho	puliho	p u l i h o	p u l i ç o
+458	1362	foeliehĕ	fulihė	f u l i h ė	f u l i ç ə
 268	1367	foforo	foforo	f o f o r o	f o f o r o
 461	1373	wakieförö	wakifu̇ru̇	w a k i f u̇ r u̇	w a k i f ɨ r ɨ
 3	1374	(è)kaèq	(E)kaE'	( E ) k a E '	( ɛ ) k a ɛ ʔ
-51	1375	aroe(w)a; adoe(w)ĕ	aru(w)a; adu(w)ė	a r u ( w ) a ; # a d u ( w ) ė	a r u ( w ) a ; # a d u ( w ) ə
+51	1375	aroe(w)a	aru(w)a	a r u ( w ) a	a r u ( w ) a
+51	1375	adoe(w)ĕ	adu(w)ė	a d u ( w ) ė	a d u ( w ) ə
 11	1377	a(o)fa	a(o)fa	a ( o ) f a	a ( o ) f a
-47	1378	arieba; aliebĕ	ariba; alibė	a r i b a ; # a l i b ė	a r i b a ; # a l i b ə
+47	1378	arieba	ariba	a r i b a	a r i b a
+47	1378	aliebĕ	alibė	a l i b ė	a l i b ə
 30	1379	akieakienĕ	akiakinė	a k i a k i n ė	a k i a k i n ə
-12	1383	a(o)fa hie a(o)fa	a(o)fa hi a(o)fa	a ( o ) f a # h i # a ( o ) f a	a ( o ) f a # h i # a ( o ) f a
+12	1383	a(o)fa_hie_a(o)fa	a(o)fa_hi_a(o)fa	a ( o ) f a _ h i _ a ( o ) f a	a ( o ) f a _ h i _ a ( o ) f a
 17	1384	abaiekaèq	abaikaE'	a b a i k a E '	a b a i k a ɛ ʔ
 346	1385	kiefa(a)oeq	kifa(a)u'	k i f a ( a ) u '	k i f a ( a ) u ʔ
-347	1386	kiefa(a)oeq hie (è)kaèq	kifa(a)u' hi (E)kaE'	k i f a ( a ) u ' # h i # ( E ) k a E '	k i f a ( a ) u ʔ # h i # ( ɛ ) k a ɛ ʔ
-348	1387	kiefa(a)oeq hie adoe(w)a	kifa(a)u' hi adu(w)a	k i f a ( a ) u ' # h i # a d u ( w ) a	k i f a ( a ) u ʔ # h i # a d u ( w ) a
-350	1388	kiefa(a)oeq hie aroe(w)a	kifa(a)u' hi aru(w)a	k i f a ( a ) u ' # h i # a r u ( w ) a	k i f a ( a ) u ʔ # h i # a r u ( w ) a
-349	1389	kiefa(a)oeq hie adoe(w)ĕ	kifa(a)u' hi adu(w)ė	k i f a ( a ) u ' # h i # a d u ( w ) ė	k i f a ( a ) u ʔ # h i # a d u ( w ) ə
-5	1390	(è)kaèq taka	(E)kaE' taka	( E ) k a E ' # t a k a	( ɛ ) k a ɛ ʔ # t a k a
-6	1391	(è)kaèq taka hie (è)kaèq	(E)kaE' taka hi (E)kaE'	( E ) k a E ' # t a k a # h i # ( E ) k a E '	( ɛ ) k a ɛ ʔ # t a k a # h i # ( ɛ ) k a ɛ ʔ
-1	1392	(è)kaeq taka hie kiefa(a)oeq	(E)kae' taka hi kifa(a)u'	( E ) k a e ' # t a k a # h i # k i f a ( a ) u '	( ɛ ) k a e ʔ # t a k a # h i # k i f a ( a ) u ʔ
-7	1393	(è)kaèq taka hie kiefa(a)oeq, hie (è)kaèq	(E)kaE' taka hi kifa(a)u', hi (E)kaE'	( E ) k a E ' # t a k a # h i # k i f a ( a ) u ' , # h i # ( E ) k a E '	( ɛ ) k a ɛ ʔ # t a k a # h i # k i f a ( a ) u ʔ , # h i # ( ɛ ) k a ɛ ʔ
-20	1397	adoe(w)a taka hie (è)kaèq	adu(w)a taka hi (E)kaE'	a d u ( w ) a # t a k a # h i # ( E ) k a E '	a d u ( w ) a # t a k a # h i # ( ɛ ) k a ɛ ʔ
-48	1398	aroe(w)a taka hie (è)kaèq	aru(w)a taka hi (E)kaE'	a r u ( w ) a # t a k a # h i # ( E ) k a E '	a r u ( w ) a # t a k a # h i # ( ɛ ) k a ɛ ʔ
-22	1399	adoe(w)ĕ taka hie (è)kaèq	adu(w)ė taka hi (E)kaE'	a d u ( w ) ė # t a k a # h i # ( E ) k a E '	a d u ( w ) ə # t a k a # h i # ( ɛ ) k a ɛ ʔ
-21	1400	adoe(w)a taka hie kiefa(a)oeq	adu(w)a taka hi kifa(a)u'	a d u ( w ) a # t a k a # h i # k i f a ( a ) u '	a d u ( w ) a # t a k a # h i # k i f a ( a ) u ʔ
-49	1401	aroe(w)a taka hie kiefa(a)oeq	aru(w)a taka hi kifa(a)u'	a r u ( w ) a # t a k a # h i # k i f a ( a ) u '	a r u ( w ) a # t a k a # h i # k i f a ( a ) u ʔ
-23	1402	adoe(w)ĕ taka hie kiefa(a)oeq	adu(w)ė taka hi kifa(a)u'	a d u ( w ) ė # t a k a # h i # k i f a ( a ) u '	a d u ( w ) ə # t a k a # h i # k i f a ( a ) u ʔ
-33	1404	akoloe taka hie kiefa(a)oeq	akolu taka hi kifa(a)u'	a k o l u # t a k a # h i # k i f a ( a ) u '	a k o l u # t a k a # h i # k i f a ( a ) u ʔ
-15	1407	a(o)pa taka hie kiefa(a)oeq	a(o)pa taka hi kifa(a)u'	a ( o ) p a # t a k a # h i # k i f a ( a ) u '	a ( o ) p a # t a k a # h i # k i f a ( a ) u ʔ
-13	1408	a(o)fa taka hie kiefa(a)oeq	a(o)fa taka hi kifa(a)u'	a ( o ) f a # t a k a # h i # k i f a ( a ) u '	a ( o ) f a # t a k a # h i # k i f a ( a ) u ʔ
-4	1414	(è)kaèq koedoroka	(E)kaE' kudoroka	( E ) k a E ' # k u d o r o k a	( ɛ ) k a ɛ ʔ # k u d o r o k a
+347	1386	kiefa(a)oeq_hie_(è)kaèq	kifa(a)u'_hi_(E)kaE'	k i f a ( a ) u ' _ h i _ ( E ) k a E '	k i f a ( a ) u ʔ _ h i _ ( ɛ ) k a ɛ ʔ
+348	1387	kiefa(a)oeq_hie_adoe(w)a	kifa(a)u'_hi_adu(w)a	k i f a ( a ) u ' _ h i _ a d u ( w ) a	k i f a ( a ) u ʔ _ h i _ a d u ( w ) a
+350	1388	kiefa(a)oeq_hie_aroe(w)a	kifa(a)u'_hi_aru(w)a	k i f a ( a ) u ' _ h i _ a r u ( w ) a	k i f a ( a ) u ʔ _ h i _ a r u ( w ) a
+349	1389	kiefa(a)oeq_hie_adoe(w)ĕ	kifa(a)u'_hi_adu(w)ė	k i f a ( a ) u ' _ h i _ a d u ( w ) ė	k i f a ( a ) u ʔ _ h i _ a d u ( w ) ə
+5	1390	(è)kaèq_taka	(E)kaE'_taka	( E ) k a E ' _ t a k a	( ɛ ) k a ɛ ʔ _ t a k a
+6	1391	(è)kaèq_taka_hie_(è)kaèq	(E)kaE'_taka_hi_(E)kaE'	( E ) k a E ' _ t a k a _ h i _ ( E ) k a E '	( ɛ ) k a ɛ ʔ _ t a k a _ h i _ ( ɛ ) k a ɛ ʔ
+1	1392	(è)kaeq_taka_hie_kiefa(a)oeq	(E)kae'_taka_hi_kifa(a)u'	( E ) k a e ' _ t a k a _ h i _ k i f a ( a ) u '	( ɛ ) k a e ʔ _ t a k a _ h i _ k i f a ( a ) u ʔ
+7	1393	(è)kaèq_taka_hie_kiefa(a)oeq,_hie_(è)kaèq	(E)kaE'_taka_hi_kifa(a)u',_hi_(E)kaE'	( E ) k a E ' _ t a k a _ h i _ k i f a ( a ) u ' , _ h i _ ( E ) k a E '	( ɛ ) k a ɛ ʔ _ t a k a _ h i _ k i f a ( a ) u ʔ , _ h i _ ( ɛ ) k a ɛ ʔ
+20	1397	adoe(w)a_taka_hie_(è)kaèq	adu(w)a_taka_hi_(E)kaE'	a d u ( w ) a _ t a k a _ h i _ ( E ) k a E '	a d u ( w ) a _ t a k a _ h i _ ( ɛ ) k a ɛ ʔ
+48	1398	aroe(w)a_taka_hie_(è)kaèq	aru(w)a_taka_hi_(E)kaE'	a r u ( w ) a _ t a k a _ h i _ ( E ) k a E '	a r u ( w ) a _ t a k a _ h i _ ( ɛ ) k a ɛ ʔ
+22	1399	adoe(w)ĕ_taka_hie_(è)kaèq	adu(w)ė_taka_hi_(E)kaE'	a d u ( w ) ė _ t a k a _ h i _ ( E ) k a E '	a d u ( w ) ə _ t a k a _ h i _ ( ɛ ) k a ɛ ʔ
+21	1400	adoe(w)a_taka_hie_kiefa(a)oeq	adu(w)a_taka_hi_kifa(a)u'	a d u ( w ) a _ t a k a _ h i _ k i f a ( a ) u '	a d u ( w ) a _ t a k a _ h i _ k i f a ( a ) u ʔ
+49	1401	aroe(w)a_taka_hie_kiefa(a)oeq	aru(w)a_taka_hi_kifa(a)u'	a r u ( w ) a _ t a k a _ h i _ k i f a ( a ) u '	a r u ( w ) a _ t a k a _ h i _ k i f a ( a ) u ʔ
+23	1402	adoe(w)ĕ_taka_hie_kiefa(a)oeq	adu(w)ė_taka_hi_kifa(a)u'	a d u ( w ) ė _ t a k a _ h i _ k i f a ( a ) u '	a d u ( w ) ə _ t a k a _ h i _ k i f a ( a ) u ʔ
+33	1404	akoloe_taka_hie_kiefa(a)oeq	akolu_taka_hi_kifa(a)u'	a k o l u _ t a k a _ h i _ k i f a ( a ) u '	a k o l u _ t a k a _ h i _ k i f a ( a ) u ʔ
+15	1407	a(o)pa_taka_hie_kiefa(a)oeq	a(o)pa_taka_hi_kifa(a)u'	a ( o ) p a _ t a k a _ h i _ k i f a ( a ) u '	a ( o ) p a _ t a k a _ h i _ k i f a ( a ) u ʔ
+13	1408	a(o)fa_taka_hie_kiefa(a)oeq	a(o)fa_taka_hi_kifa(a)u'	a ( o ) f a _ t a k a _ h i _ k i f a ( a ) u '	a ( o ) f a _ t a k a _ h i _ k i f a ( a ) u ʔ
+4	1414	(è)kaèq_koedoroka	(E)kaE'_kudoroka	( E ) k a E ' _ k u d o r o k a	( ɛ ) k a ɛ ʔ _ k u d o r o k a


### PR DESCRIPTION
This commit solved the issue laid out [here](https://github.com/engganolang/helfrich-1916-wordlist/issues/5) for the forms, variants, and crossreferences.