### PR TITLE
Fix error for illegal quoting in Indonesian translation

### DIFF
--- a/Helfrich-1916-wordlist.R
+++ b/Helfrich-1916-wordlist.R
@@ -93,6 +93,8 @@ hform |>
   # join the Indonesian translation
   left_join(en_to_idn_via_deeplr) |> 
   select(ID, page, entry, dutch, english, indonesian, everything()) |> 
+  mutate(indonesian = str_replace_all(indonesian, '\\"(?!\\s)', '“'),
+         indonesian = str_replace_all(indonesian, '\\"(?=\\s)', '”')) |> 
   write_tsv("data/helfrich1916.tsv", na = "")
 
 # save the variant table

--- a/data/helfrich1916.tsv
+++ b/data/helfrich1916.tsv
@@ -423,7 +423,7 @@ ID	page	entry	dutch	english	indonesian	form	variant_ID	form_common_transcription
 412	486	E	vliegen , stuiven , opstuiven van stof enz	flying , dusting , kicking up dust etc.	terbang, membersihkan debu, menendang debu, dll.	kieèèpa	344	kiEEpa	k i E E p a	k i ɛ ɛ p a						
 413	486	E	korte breede bijl	short broad axe	kapak lebar pendek	èkèh(è)		EkEh(E)	E k E h ( E )	ɛ k ɛ h ( ɛ )						
 414	486	E	doorn	thorn	duri	èkèhèodo		EkEhEodo	E k E h E o d o	ɛ k ɛ h ɛ o d o						
-415	486	E	een instrumentje , dat men tusschen de tanden neemt en daarmede het geluid «ginggong» maakt	a small instrument , which one takes between the teeth and with which one makes the sound “ginggong”	alat musik kecil, yang diambil di antara gigi dan dengan alat musik itu mengeluarkan suara ""ginggong""	èkèkong		EkEkong	E k E k o n g	ɛ k ɛ k o n g						
+415	486	E	een instrumentje , dat men tusschen de tanden neemt en daarmede het geluid «ginggong» maakt	a small instrument , which one takes between the teeth and with which one makes the sound “ginggong”	alat musik kecil, yang diambil di antara gigi dan dengan alat musik itu mengeluarkan suara “ginggong“	èkèkong		EkEkong	E k E k o n g	ɛ k ɛ k o n g						
 416	486	E	milt	spleen	limpa	èkèma		EkEma	E k E m a	ɛ k ɛ m a						
 417	486	E	braken	vomit	muntah	èkèoäh		EkEo'ah	E k E o ' a h	ɛ k ɛ o ʔ a h						
 418	486	E	rottan	rottan	rotan	èkèoq		EkEo'	E k E o '	ɛ k ɛ o ʔ						
@@ -763,8 +763,8 @@ ID	page	entry	dutch	english	indonesian	form	variant_ID	form_common_transcription
 745	494	IE	daarbinnen	within that	dalam hal itu	iehoie(j)ana		ihoi(y)ana	i h o i ( y ) a n a	i ç o i ( j ) a n a						
 746	495	IE	kracht , krachtig , sterk	force , powerful , strong	kekuatan, kuat, kuat	ie(j)aäo		i(y)a'ao	i ( y ) a ' a o	i ( j ) a ʔ a o						
 747	495	IE	geschild , gepeld , gevild	peeled , skinned	dikupas, dikuliti	ie(j)abie		i(y)abi	i ( y ) a b i	i ( j ) a b i						
-748	495	IE	zie haie	see “haie”	lihat ""haie""	ie(j)aha(ie)	269	i(y)aha(i)	i ( y ) a h a ( i )	i ( j ) a h a ( i )	haie	hai	h a i	705	h a i	
-749	495	IE	gezegd van iemand die tot een andere «soekoe» dan de zijne behoort	said of someone who belongs to a “suku” other than his own	dikatakan tentang seseorang yang berasal dari ""suku"" selain suku sendiri	ie(j)ahaoeoeaq		i(y)ahau'ua'	i ( y ) a h a u ' u a '	i ( j ) a h a u ʔ u a ʔ						
+748	495	IE	zie haie	see “haie”	lihat “haie“	ie(j)aha(ie)	269	i(y)aha(i)	i ( y ) a h a ( i )	i ( j ) a h a ( i )	haie	hai	h a i	705	h a i	
+749	495	IE	gezegd van iemand die tot een andere «soekoe» dan de zijne behoort	said of someone who belongs to a “suku” other than his own	dikatakan tentang seseorang yang berasal dari “suku” selain suku sendiri	ie(j)ahaoeoeaq		i(y)ahau'ua'	i ( y ) a h a u ' u a '	i ( j ) a h a u ʔ u a ʔ						
 750	495	IE	hiel ; met de hielen trappen	heel ; kicking with the heels	tumit; menendang dengan tumit	ie(j)o		i(y)o	i ( y ) o	i ( j ) o						
 751	495	IE	dan , bij den vergelijkenden trap	than , for comparisons	dari , untuk perbandingan	ie(j)oho		i(y)oho	i ( y ) o h o	i ( j ) o h o						
 752	495	IE	ondiep , niet diep	shallow , not deep	dangkal, tidak dalam	ie(j)okie		i(y)oki	i ( y ) o k i	i ( j ) o k i						
@@ -799,9 +799,9 @@ ID	page	entry	dutch	english	indonesian	form	variant_ID	form_common_transcription
 781	496	K	meer , over , te veel , overschot	more , left over , too much , surplus	lebih banyak , sisa , terlalu banyak , surplus	kaäkieè		ka'akiE	k a ' a k i E	k a ʔ a k i ɛ						
 782	496	K	het gevoel in de tanden , wanneer ze met iets zuurs in aanraking komen	the feeling in the teeth when they come into contact with something acidic	perasaan di gigi ketika mereka bersentuhan dengan sesuatu yang asam	kaäkiekie(j)ĕ		ka'akiki(y)ė	k a ' a k i k i ( y ) ė	k a ʔ a k i k i ( j ) ə						
 783	496	K	blauw , donkerblauw	blue , dark blue	biru, biru tua	kaäkienafah		ka'akinafah	k a ' a k i n a f a h	k a ʔ a k i n a f a h						
-784	496	K	gew. verbonden met : «èbaka» ; blind.	usually connected with : “èbaka” ; blind	biasanya dihubungkan dengan : ""èbaka"" ; buta	kaäkienè	290	ka'akinE	k a ' a k i n E	k a ʔ a k i n ɛ	èbaka	Ebaka	E b a k a	214	ɛ b a k a	
-784	496	K	gew. verbonden met : «èbaka» ; blind.	usually connected with : “èbaka” ; blind	biasanya dihubungkan dengan : ""èbaka"" ; buta	kaäkienè	290	ka'akinE	k a ' a k i n E	k a ʔ a k i n ɛ	èbaka	Ebaka	E b a k a	215	ɛ b a k a	
-784	496	K	gew. verbonden met : «èbaka» ; blind.	usually connected with : “èbaka” ; blind	biasanya dihubungkan dengan : ""èbaka"" ; buta	kaäkienè	290	ka'akinE	k a ' a k i n E	k a ʔ a k i n ɛ	èbaka	Ebaka	E b a k a	234	ɛ b a k a	
+784	496	K	gew. verbonden met : «èbaka» ; blind.	usually connected with : “èbaka” ; blind	biasanya dihubungkan dengan : “èbaka” ; buta	kaäkienè	290	ka'akinE	k a ' a k i n E	k a ʔ a k i n ɛ	èbaka	Ebaka	E b a k a	214	ɛ b a k a	
+784	496	K	gew. verbonden met : «èbaka» ; blind.	usually connected with : “èbaka” ; blind	biasanya dihubungkan dengan : “èbaka” ; buta	kaäkienè	290	ka'akinE	k a ' a k i n E	k a ʔ a k i n ɛ	èbaka	Ebaka	E b a k a	215	ɛ b a k a	
+784	496	K	gew. verbonden met : «èbaka» ; blind.	usually connected with : “èbaka” ; blind	biasanya dihubungkan dengan : “èbaka” ; buta	kaäkienè	290	ka'akinE	k a ' a k i n E	k a ʔ a k i n ɛ	èbaka	Ebaka	E b a k a	234	ɛ b a k a	
 785	496	K	groen	green	hijau	kaäkieniepa	291	ka'akinipa	k a ' a k i n i p a	k a ʔ a k i n i p a						
 786	496	K	kracht , krachtig , sterk	force , powerful , strong	kekuatan, kuat, kuat	kaäkoeka(h)		ka'akuka(h)	k a ' a k u k a ( h )	k a ʔ a k u k a ( h )						
 787	496	K	zwart , donkerkleurig	black , dark-coloured	hitam, berwarna gelap	kaäkoho		ka'akoho	k a ' a k o h o	k a ʔ a k o h o						
@@ -901,7 +901,7 @@ ID	page	entry	dutch	english	indonesian	form	variant_ID	form_common_transcription
 881	498	K	overkomen van ongelukken	have accidents happen	mengalami kecelakaan terjadi	kamanaä		kamana'a	k a m a n a ' a	k a m a n a ʔ a						
 882	498	K	niet willen , niet verlangen	not wanting , not desiring	tidak menginginkan , tidak menginginkan	kamoepie	319	kamupi	k a m u p i	k a m u p i						
 883	498	K	iets wat pas uitstoelt , wat pas opkomt van aanplantingen	something that recently came out , that recently emerged from plantings	sesuatu yang baru saja keluar, yang baru saja muncul dari penanaman	kamoenieno		kamunino	k a m u n i n o	k a m u n i n o						
-884	498	K	het mal. : «maka»	the Malay : “maka”	bahasa Melayu: ""maka""	kamoho		kamoho	k a m o h o	k a m o h o						
+884	498	K	het mal. : «maka»	the Malay : “maka”	bahasa Melayu: “maka“	kamoho		kamoho	k a m o h o	k a m o h o						
 885	498	K	zoet , lief , innemend	sweet , sweet , engaging	manis, manis, menarik	kamonie		kamoni	k a m o n i	k a m o n i						
 886	499	K	een van de typen van eene Engganeesche lans	one of the types of an Engganese lance	salah satu jenis tombak Engganese	kanakienie		kanakini	k a n a k i n i	k a n a k i n i						
 887	499	K	oud mannetje ; oud vrouwtje	old male ; old female	laki-laki tua; perempuan tua	kanapoe		kanapu	k a n a p u	k a n a p u						
@@ -930,7 +930,7 @@ ID	page	entry	dutch	english	indonesian	form	variant_ID	form_common_transcription
 910	499	K	het ophouden , omhooghouden om iets op te vangen	holding up , holding up to catch something	mengangkat , mengangkat untuk menangkap sesuatu	kaoedèqää		kaudE'a'a	k a u d E ' a ' a	k a u d ɛ ʔ a ʔ a						
 911	499	K	plein van eene doesoen	square of a doesoen	kuadrat dari sebuah doesoen	kaoenie(j)a		kauni(y)a	k a u n i ( y ) a	k a u n i ( j ) a						
 912	499	K	nog niet , nog nooit	not yet , never yet	belum, belum pernah	kaoepè(q)	325	kaupE(')	k a u p E ( ' )	k a u p ɛ ( ʔ )						
-913	499	K	mooi , fraai , goed ; aangenaam voor de zintuigen inz. lekker om te eten V.g.l. : èkaoe(w)a	beautiful , handsome , good ; pleasing to the senses e.g. , nice to eat ; cf. : “èkaoe(w)a”	cantik, tampan, bagus; menyenangkan hati, misalnya: enak dimakan; lih: ""èkaoe(w)a""	kaoe(w)a	323	kau(w)a	k a u ( w ) a	k a u ( w ) a	èkaoe(w)a	Ekau(w)a	E k a u ( w ) a	399	ɛ k a u ( w ) a	
+913	499	K	mooi , fraai , goed ; aangenaam voor de zintuigen inz. lekker om te eten V.g.l. : èkaoe(w)a	beautiful , handsome , good ; pleasing to the senses e.g. , nice to eat ; cf. : “èkaoe(w)a”	cantik, tampan, bagus; menyenangkan hati, misalnya: enak dimakan; lih: “èkaoe(w)a“	kaoe(w)a	323	kau(w)a	k a u ( w ) a	k a u ( w ) a	èkaoe(w)a	Ekau(w)a	E k a u ( w ) a	399	ɛ k a u ( w ) a	
 914	499	K	zout , brak	saline , brackish	garam, payau	kaoe(w)èoe(w)è		kau(w)Eu(w)E	k a u ( w ) E u ( w ) E	k a u ( w ) ɛ u ( w ) ɛ						
 915	499	K	zwart	black	hitam	kaoe(w)ie		kau(w)i	k a u ( w ) i	k a u ( w ) i						
 916	499	K	ebbe , vallen van het water	ebb , falling of the water	surut, jatuhnya air	kaokie		kaoki	k a o k i	k a o k i						
@@ -1055,9 +1055,9 @@ ID	page	entry	dutch	english	indonesian	form	variant_ID	form_common_transcription
 1034	503	K	zijn , wezen , bestaan , leven , gebeuren , er is	being , being , existence , life , happening , there is	menjadi , keberadaan , keberadaan , kehidupan , terjadi , ada	kiekie(j)a	371	kiki(y)a	k i k i ( y ) a	k i k i ( j ) a						
 1035	503	K	tegenstribbelen , zich verzetten	balk , resist	menolak, menolak	kiekie(j)aqkie(j)aq		kiki(y)a'ki(y)a'	k i k i ( y ) a ' k i ( y ) a '	k i k i ( j ) a ʔ k i ( j ) a ʔ						
 1036	503	K	alleen overblijven , achterblijven , blijven liggen van werk	left alone , left behind , left over from work	ditinggal sendirian, ditinggal, ditinggal kerja	kiekie(j)ara		kiki(y)ara	k i k i ( y ) a r a	k i k i ( j ) a r a						
-1037	503	K	gew. verbonden met : «èbaka» , knipoogen	usually connected with : “èbaka” , winking	biasanya dihubungkan dengan : ""èbaka"" , mengedipkan mata	kiekie(j)o		kiki(y)o	k i k i ( y ) o	k i k i ( j ) o	èbaka	Ebaka	E b a k a	214	ɛ b a k a	
-1037	503	K	gew. verbonden met : «èbaka» , knipoogen	usually connected with : “èbaka” , winking	biasanya dihubungkan dengan : ""èbaka"" , mengedipkan mata	kiekie(j)o		kiki(y)o	k i k i ( y ) o	k i k i ( j ) o	èbaka	Ebaka	E b a k a	215	ɛ b a k a	
-1037	503	K	gew. verbonden met : «èbaka» , knipoogen	usually connected with : “èbaka” , winking	biasanya dihubungkan dengan : ""èbaka"" , mengedipkan mata	kiekie(j)o		kiki(y)o	k i k i ( y ) o	k i k i ( j ) o	èbaka	Ebaka	E b a k a	234	ɛ b a k a	
+1037	503	K	gew. verbonden met : «èbaka» , knipoogen	usually connected with : “èbaka” , winking	biasanya dihubungkan dengan : “èbaka” , mengedipkan mata	kiekie(j)o		kiki(y)o	k i k i ( y ) o	k i k i ( j ) o	èbaka	Ebaka	E b a k a	214	ɛ b a k a	
+1037	503	K	gew. verbonden met : «èbaka» , knipoogen	usually connected with : “èbaka” , winking	biasanya dihubungkan dengan : “èbaka” , mengedipkan mata	kiekie(j)o		kiki(y)o	k i k i ( y ) o	k i k i ( j ) o	èbaka	Ebaka	E b a k a	215	ɛ b a k a	
+1037	503	K	gew. verbonden met : «èbaka» , knipoogen	usually connected with : “èbaka” , winking	biasanya dihubungkan dengan : “èbaka” , mengedipkan mata	kiekie(j)o		kiki(y)o	k i k i ( y ) o	k i k i ( j ) o	èbaka	Ebaka	E b a k a	234	ɛ b a k a	
 1038	503	K	fijn hakken zooals fricadel	finely chopped like meatballs	cincang halus seperti bakso	kiekienie		kikini	k i k i n i	k i k i n i						
 1039	503	K	zorg , moeite , last	care , trouble , burden	perawatan, masalah, beban	kiekoekoe(q)ö	372	kikuku(')u̇	k i k u k u ( ' ) u̇	k i k u k u ( ʔ ) ɨ						
 1040	503	K	blazen van slangen en katten	hissing of snakes and cats	desisan ular dan kucing	kiekoho		kikoho	k i k o h o	k i k o h o						
@@ -1296,7 +1296,7 @@ ID	page	entry	dutch	english	indonesian	form	variant_ID	form_common_transcription
 1266	510	P	het feest gegeven bij het te water laten van een sampan	the party given at the launch of a sampan	pesta yang diberikan pada saat peluncuran sampan	pahakè(j)aq		pahakE(y)a'	p a h a k E ( y ) a '	p a h a k ɛ ( j ) a ʔ						
 1267	510	P	rots , gesteente	rock , stone	batu, batu	pahakie(j)a	445	pahaki(y)a	p a h a k i ( y ) a	p a h a k i ( j ) a						
 1268	510	P	vast , standvastig , bestendig	firm , steadfast , resistant	tegas, tabah, tahan	pahakoienanaq		pahakoinana'	p a h a k o i n a n a '	p a h a k o i n a n a ʔ						
-1269	510	P	de korte redevoering gehouden bij het «kaléak(oe)baba» feest	The short speech delivered at the “kaléak(oe)baba” celebration	Pidato singkat yang disampaikan pada perayaan ""kaléak(oe)baba""	pahaö		paha'o	p a h a ' o	p a h a ʔ o						
+1269	510	P	de korte redevoering gehouden bij het «kaléak(oe)baba» feest	The short speech delivered at the “kaléak(oe)baba” celebration	Pidato singkat yang disampaikan pada perayaan “kaléak(oe)baba“	pahaö		paha'o	p a h a ' o	p a h a ʔ o						
 1270	510	P	in bedwang houden , beletten	restrain , prevent	menahan, mencegah	pahapèaq		pahapEa'	p a h a p E a '	p a h a p ɛ a ʔ						
 1271	510	P	voltooid , klaar , gereed ; ook : verzameld , bijeen	completed , finished , ready ; also : gathered , assembled	selesai, sudah selesai, siap; juga: berkumpul, berkumpul	pahapoeè(q)	240	pahapuE(')	p a h a p u E ( ' )	p a h a p u ɛ ( ʔ )						
 1272	510	P	het van plaats veranderen , zich verplaatsen	changing place , moving around	berganti tempat, berpindah-pindah	pahjo	242	pahyo	p a h y o	p a h j o						


### PR DESCRIPTION
This is further fix related to issue [#4](https://github.com/engganolang/helfrich-1916-wordlist/issues/4)